### PR TITLE
UNR-2898 - Update max player/spectator number

### DIFF
--- a/Game/Config/DefaultGame.ini
+++ b/Game/Config/DefaultGame.ini
@@ -7,3 +7,6 @@ bSpatialNetworking=True
 +DirectoriesToAlwaysCook=(Path="Spatial")
 bCookAll=True
 
+[/Script/Engine.GameSession]
+MaxPlayers=1000
+MaxSpectators=1000


### PR DESCRIPTION
All runs of this project can only have at most 16 players, as the MaxPlayers setting in the engine’s BaseGame.ini is never being overwritten.

See https://improbableio.atlassian.net/browse/UNR-2898 for context.

@danielimprobable @m-samiec @spatialos/develop-unreal