### PR TITLE
Add fps output, used by NFR pipeline

### DIFF
--- a/Game/Config/DefaultEngine.ini
+++ b/Game/Config/DefaultEngine.ini
@@ -3,7 +3,7 @@ GameDefaultMap=/Game/Maps/EmptyGym.EmptyGym
 EditorStartupMap=/Game/Maps/EmptyGym.EmptyGym
 ServerDefaultMap=/Game/Maps/EmptyGym.EmptyGym
 GlobalDefaultGameMode=/Game/GameModes/GDKTestGymsGameMode.GDKTestGymsGameMode_C
-GameInstanceClass=/Script/SpatialGDK.SpatialGameInstance
+GameInstanceClass=/Script/GDKTestGyms.GDKTestGymsGameInstance
 
 [/Script/IOSRuntimeSettings.IOSRuntimeSettings]
 MinimumiOSVersion=IOS_11
@@ -84,5 +84,4 @@ InitialAverageFrameRate=0.016667
 PhysXTreeRebuildRate=10
 DefaultBroadphaseSettings=(bUseMBPOnClient=False,bUseMBPOnServer=False,bUseMBPOuterBounds=False,MBPBounds=(Min=(X=0.000000,Y=0.000000,Z=0.000000),Max=(X=0.000000,Y=0.000000,Z=0.000000),IsValid=0),MBPOuterBounds=(Min=(X=0.000000,Y=0.000000,Z=0.000000),Max=(X=0.000000,Y=0.000000,Z=0.000000),IsValid=0),MBPNumSubdivs=2)
 ChaosSettings=(DefaultThreadingModel=DedicatedThread,DedicatedThreadTickMode=VariableCappedWithTarget,DedicatedThreadBufferMode=Double)
-
 

--- a/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.cpp
+++ b/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.cpp
@@ -8,6 +8,11 @@ void UGDKTestGymsGameInstance::Init()
 {
 	Super::Init();
 
+	if (GEngine)
+	{
+		GEngine->SetMaxFPS(90.f);
+	}
+
 	TickDelegate = FTickerDelegate::CreateUObject(this, &UGDKTestGymsGameInstance::Tick);
 	TickDelegateHandle = FTicker::GetCoreTicker().AddTicker(TickDelegate);
 }
@@ -15,7 +20,7 @@ void UGDKTestGymsGameInstance::Init()
 bool UGDKTestGymsGameInstance::Tick(float DeltaSeconds)
 {
 	float Alpha = 0.8f;
-	float CurrFPS = 1.0f / DeltaSeconds;
+	float CurrFPS = 1.0f / DeltaSeconds; // TODO - we should remove FApp::GetIdleTime() from DeltaSeconds once the NFR regex is fixed
 	AverageFPS = (Alpha * AverageFPS) + ((1.0f - Alpha) * CurrFPS);
 
 	SecondsSinceFPSLog += DeltaSeconds;

--- a/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.cpp
+++ b/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "GDKTestGymsGameInstance.h"
+
+#include "EngineMinimal.h"
+
+void UGDKTestGymsGameInstance::Init()
+{
+	Super::Init();
+
+	TickDelegate = FTickerDelegate::CreateUObject(this, &UGDKTestGymsGameInstance::Tick);
+	TickDelegateHandle = FTicker::GetCoreTicker().AddTicker(TickDelegate);
+}
+
+bool UGDKTestGymsGameInstance::Tick(float DeltaSeconds)
+{
+	float Alpha = 0.8f;
+	float CurrFPS = 1.0f / DeltaSeconds;
+	AverageFPS = (Alpha * AverageFPS) + ((1.0f - Alpha) * CurrFPS);
+
+	SecondsSinceFPSLog += DeltaSeconds;
+
+	if (SecondsSinceFPSLog > 1.0f) 
+	{
+		SecondsSinceFPSLog = 0.0f;
+#if !WITH_EDITOR // Don't pollute logs in editor
+		UE_LOG(LogTemp, Display, TEXT("FramesPerSecond is %f"), AverageFPS);
+#endif
+	}
+
+	return true;
+}

--- a/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.h
+++ b/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.h
@@ -19,6 +19,6 @@ private:
 	FTickerDelegate TickDelegate;
 	FDelegateHandle TickDelegateHandle;
 
-	float AverageFPS = 1.0f;
+	float AverageFPS = 60.0f;
 	float SecondsSinceFPSLog = 0.0f;
 };

--- a/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.h
+++ b/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.h
@@ -1,0 +1,24 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SpatialGameInstance.h"
+#include "GDKTestGymsGameInstance.generated.h"
+
+UCLASS()
+class GDKTESTGYMS_API UGDKTestGymsGameInstance : public USpatialGameInstance
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Init() override;
+	bool Tick(float DeltaSeconds);
+
+private:
+	FTickerDelegate TickDelegate;
+	FDelegateHandle TickDelegateHandle;
+
+	float AverageFPS = 1.0f;
+	float SecondsSinceFPSLog = 0.0f;
+};

--- a/LaunchSimClient.bat
+++ b/LaunchSimClient.bat
@@ -1,0 +1,4 @@
+@echo off
+call "%~dp0FindEngine.bat"
+call "%~dp0ProjectPaths.bat"
+"%UNREAL_ENGINE:"=%\Engine\Binaries\Win64\UE4Editor.exe" "%~dp0%PROJECT_PATH%\%GAME_NAME%.uproject" 127.0.0.1?simulatedPlayer=1 -simulatedPlayer -game -log -workerType UnrealClient -stdout -nowrite -unattended -nologtimes -nopause -noin -messaging -NoVerifyGC -windowed -ResX=800 -ResY=600


### PR DESCRIPTION
FPS output is required by NFR pipeline to deduce the health of workers.

