### PR TITLE
Feature/GV-329 New NFR parameter and new span name format

### DIFF
--- a/spatial/workers/unreal/spatialos.UnrealWorker.worker.json
+++ b/spatial/workers/unreal/spatialos.UnrealWorker.worker.json
@@ -76,7 +76,7 @@
         "${IMPROBABLE_WORKER_ID}",
         "+deploymentName",
         "${IMPROBABLE_DEPLOYMENT_NAME}",
-        "-tracePrefix",
+        "-traceMetadata",
         "${IMPROBABLE_DEPLOYMENT_NAME}",
         "+linkProtocol",
         "Tcp",


### PR DESCRIPTION
This PR is is one of four related ones (from major to minor):
* [NFR Framework](https://github.com/improbable/nfr-benchmark-pipeline/pull/116)
* [UnrealGDK](https://github.com/spatialos/UnrealGDK/pull/1975)
* [TestGymBuildkite](https://github.com/improbable/TestGymBuildKite/pull/57)
* [UnrealGDKTestGyms](https://github.com/spatialos/UnrealGDKTestGyms/pull/68)

These PRs implement/accommodate two changes to NFR latency testing:

**New required "trace descriptions" parameter**
Users now have to supply "trace descriptions". The framework will now only include traces whose root span names include one of the user-cupplied trace descriptions. This gives users more control over what exact interactions they want to log.

**Span name format change**
The format of span names has been updated so that root span names now always start with the trace description. This allows users to compare traces with the same description _across_ deployments on Stackdriver's "Trace List" page (as the only supported span name filter only matches prefixes).

**Testing**
A test build that covers all four affected branches has been kicked off here:
https://buildkite.com/improbable/unrealgdk-nfr/builds/1269