### PR TITLE
[UNR-3678][MS] Consistent metric timers for GDK and native

### DIFF
--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -167,7 +167,7 @@ void ABenchmarkGymGameModeBase::TickPlayersConnectedCheck(float DeltaSeconds)
 		return;
 	}
 
-	UNFRConstants* Constants = UNFRConstants::Get(GetWorld());
+	const UNFRConstants* Constants = UNFRConstants::Get(GetWorld());
 	check(Constants);
 
 	// This test respects the initial delay timer in both native and GDK
@@ -202,7 +202,7 @@ void ABenchmarkGymGameModeBase::TickServerFPSCheck(float DeltaSeconds)
 		return;
 	}
 
-	UNFRConstants* Constants = UNFRConstants::Get(World);
+	const UNFRConstants* Constants = UNFRConstants::Get(World);
 	check(Constants);
 
 	const float FPS = GameInstance->GetAveragedFPS();
@@ -238,7 +238,7 @@ void ABenchmarkGymGameModeBase::TickClientFPSCheck(float DeltaSeconds)
 		}
 	}
 
-	UNFRConstants* Constants = UNFRConstants::Get(GetWorld());
+	const UNFRConstants* Constants = UNFRConstants::Get(GetWorld());
 	check(Constants);
 
 	if (!bClientFpsWasValid &&
@@ -295,7 +295,7 @@ void ABenchmarkGymGameModeBase::TickUXMetricCheck(float DeltaSeconds)
 	AveragedClientRTTSeconds = ClientRTTSeconds;
 	AveragedClientUpdateTimeDeltaSeconds = ClientUpdateTimeDeltaSeconds;
 
-	UNFRConstants* Constants = UNFRConstants::Get(GetWorld());
+	const UNFRConstants* Constants = UNFRConstants::Get(GetWorld());
 	check(Constants);
 
 	const bool bUXMetricValid = AveragedClientRTTSeconds <= MaxClientRoundTripSeconds && AveragedClientUpdateTimeDeltaSeconds <= MaxClientUpdateTimeDeltaSeconds;
@@ -307,14 +307,12 @@ void ABenchmarkGymGameModeBase::TickUXMetricCheck(float DeltaSeconds)
 		bHasUxFailed = true;
 		NFR_LOG(LogBenchmarkGymGameModeBase, Error, TEXT("UX metric has failed. RTT: %.8f, UpdateDelta: %.8f, ActivePlayers: %d"), AveragedClientRTTSeconds, AveragedClientUpdateTimeDeltaSeconds, ActivePlayers);
 	}
-	else
+
+	PrintUXMetricTimer -= DeltaSeconds;
+	if (PrintUXMetricTimer < 0.0f)
 	{
-		PrintUXMetricTimer -= DeltaSeconds;
-		if (PrintUXMetricTimer < 0.0f)
-		{
-			PrintUXMetricTimer = 10.0f;
-			NFR_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("UX metric values. RTT: %.8f(%d), UpdateDelta: %.8f(%d), ActivePlayers: %d"), AveragedClientRTTSeconds, ValidRTTCount, AveragedClientUpdateTimeDeltaSeconds, ValidUpdateTimeDeltaCount, ActivePlayers);
-		}
+		PrintUXMetricTimer = 10.0f;
+		NFR_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("UX metric values. RTT: %.8f(%d), UpdateDelta: %.8f(%d), ActivePlayers: %d"), AveragedClientRTTSeconds, ValidRTTCount, AveragedClientUpdateTimeDeltaSeconds, ValidUpdateTimeDeltaCount, ActivePlayers);
 	}
 }
 

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -242,7 +242,7 @@ void ABenchmarkGymGameModeBase::TickClientFPSCheck(float DeltaSeconds)
 	check(Constants);
 
 	if (!bClientFpsWasValid &&
-		Constants->ServerFPSMetricDelay.IsReady())
+		Constants->ClientFPSMetricDelay.IsReady())
 	{
 		bHasClientFpsFailed = true;
 		NFR_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("FPS check failed. A client has failed."));

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -163,6 +163,7 @@ void ABenchmarkGymGameModeBase::TickPlayersConnectedCheck(float DeltaSeconds)
 		return;
 	}
 
+	// Only check players once
 	if (bHasDonePlayerCheck)
 	{
 		return;

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -172,6 +172,7 @@ void ABenchmarkGymGameModeBase::TickPlayersConnectedCheck(float DeltaSeconds)
 	const UNFRConstants* Constants = UNFRConstants::Get(GetWorld());
 	check(Constants);
 
+	// This test respects the initial delay timer in both native and GDK
 	if (Constants->PlayerCheckValid())
 	{
 		bHasDonePlayerCheck = true;

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -42,16 +42,17 @@ protected:
 
 private:
 
+	bool IsUsingSpatialNetworking;
+
 	// Test scenarios
-	float SecondsTillPlayerCheck;
 	float PrintUXMetric;
 	double AveragedClientRTTSeconds; // The stored average of all the client RTTs
 	double AveragedClientUpdateTimeDeltaSeconds; // The stored average of the client view delta.
 	int32 MaxClientRoundTripSeconds; // Maximum allowed roundtrip
 	int32 MaxClientUpdateTimeDeltaSeconds;
-	bool bPlayersHaveJoined;
 	bool bHasUxFailed;
 	bool bHasFpsFailed;
+	bool bHasDonePlayerCheck;
 	bool bHasClientFpsFailed;
 	int32 ActivePlayers; // A count of visible UX components
 
@@ -62,7 +63,7 @@ private:
 
 	void TickPlayersConnectedCheck(float DeltaSeconds);
 	void TickServerFPSCheck(float DeltaSeconds);
-	void TickAuthServerFPSCheck(float DeltaSeconds);
+	void TickClientFPSCheck(float DeltaSeconds);
 	void TickUXMetricCheck(float DeltaSeconds);
 
 	void SetTotalNPCs(int32 Value);
@@ -72,6 +73,10 @@ private:
 	double GetPlayersConnected() const { return ActivePlayers; }
 	double GetFPSValid() const { return !bHasFpsFailed ? 1.0 : 0.0; }
 	double GetClientFPSValid() const { return !bHasClientFpsFailed ? 1.0 : 0.0; }
+
+	void FailServerFPSCheck(const float FPS);
+	void FailClientFPSCheck();
+	void FailUXMetricCheck();
 
 	UFUNCTION()
 	void OnRepTotalNPCs();

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -42,7 +42,7 @@ protected:
 
 private:
 
-	bool IsUsingSpatialNetworking;
+	bool bIsUsingSpatialNetworking;
 
 	// Test scenarios
 	float PrintUXMetric;

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -72,10 +72,6 @@ private:
 	double GetFPSValid() const { return !bHasFpsFailed ? 1.0 : 0.0; }
 	double GetClientFPSValid() const { return !bHasClientFpsFailed ? 1.0 : 0.0; }
 
-	void FailServerFPSCheck(const float FPS);
-	void FailClientFPSCheck();
-	void FailUXMetricCheck();
-
 	UFUNCTION()
 	void OnRepTotalNPCs();
 };

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -42,10 +42,8 @@ protected:
 
 private:
 
-	bool bIsUsingSpatialNetworking;
-
 	// Test scenarios
-	float PrintUXMetric;
+	float PrintUXMetricTimer;
 	double AveragedClientRTTSeconds; // The stored average of all the client RTTs
 	double AveragedClientUpdateTimeDeltaSeconds; // The stored average of the client view delta.
 	int32 MaxClientRoundTripSeconds; // Maximum allowed roundtrip

--- a/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.h
+++ b/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.h
@@ -30,7 +30,6 @@ public:
 	void NetworkFailureEventCallback(UWorld* World, UNetDriver* NetDriver, ENetworkFailure::Type FailureType, const FString& ErrorString);
 
 	const UNFRConstants* GetNFRConstants() const { return NFRConstants; }
-
 private:
 	using FPSTimePoint = TPair<int64, int64>; // Real, FrameDelta
 	int64 TickWindowTotal;

--- a/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.h
+++ b/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.h
@@ -29,7 +29,8 @@ public:
 	float GetAveragedFPS() const { return AverageFPS; }
 	void NetworkFailureEventCallback(UWorld* World, UNetDriver* NetDriver, ENetworkFailure::Type FailureType, const FString& ErrorString);
 
-	const UNFRConstants* GetNFRConstants() const { return NFRConstants; }
+	UNFRConstants* GetNFRConstants() const { return NFRConstants; }
+
 private:
 	using FPSTimePoint = TPair<int64, int64>; // Real, FrameDelta
 	int64 TickWindowTotal;

--- a/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.h
+++ b/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.h
@@ -29,7 +29,7 @@ public:
 	float GetAveragedFPS() const { return AverageFPS; }
 	void NetworkFailureEventCallback(UWorld* World, UNetDriver* NetDriver, ENetworkFailure::Type FailureType, const FString& ErrorString);
 
-	UNFRConstants* GetNFRConstants() const { return NFRConstants; }
+	const UNFRConstants* GetNFRConstants() const { return NFRConstants; }
 
 private:
 	using FPSTimePoint = TPair<int64, int64>; // Real, FrameDelta

--- a/Game/Source/GDKTestGyms/Private/NFRConstants.cpp
+++ b/Game/Source/GDKTestGyms/Private/NFRConstants.cpp
@@ -7,11 +7,7 @@
 
 DEFINE_LOG_CATEGORY(LogNFRConstants);
 
-FMetricDelay::FMetricDelay()
-{
-}
-
-FMetricDelay::FMetricDelay(int64 Seconds)
+FMetricDelay::FMetricDelay(float Seconds)
 {
 	SetDelay(Seconds);
 }

--- a/Game/Source/GDKTestGyms/Private/NFRConstants.cpp
+++ b/Game/Source/GDKTestGyms/Private/NFRConstants.cpp
@@ -7,24 +7,48 @@
 
 DEFINE_LOG_CATEGORY(LogNFRConstants);
 
-bool UNFRConstants::SamplesForFPSValid() const
+bool UNFRConstants::DoValidityCheck(bool& IsValid, int64 TimeToStart) const
 {
 	checkf(bIsInitialised, TEXT("NFRConstants not initialised"));
-	if (bFPSSamplingValid)
+	if (IsValid)
 	{
 		return true;
 	}
-	bool bIsValidNow = FDateTime::Now().GetTicks() > TimeToStartFPSSampling;
-	if (bIsValidNow)
+
+	if (FDateTime::Now().GetTicks() > TimeToStart)
 	{
-		bFPSSamplingValid = true;
+		IsValid = true;
 	}
-	return bIsValidNow;
+
+	return IsValid;
 }
 
-void UNFRConstants::InitWithWorld(UWorld* World)
+bool UNFRConstants::PlayerCheckValid() const
 {
-	TimeToStartFPSSampling = FDateTime::Now().GetTicks() + FTimespan::FromSeconds(120.0f).GetTicks();
+	return DoValidityCheck(bPlayerCheckValid, TimeToStartPlayerCheck);
+}
+
+bool UNFRConstants::SamplesForServerFPSValid() const
+{
+	return DoValidityCheck(bServerFPSSamplingValid, TimeToStartServerFPSSampling);
+}
+
+bool UNFRConstants::SamplesForClientFPSValid() const
+{
+	return DoValidityCheck(bClientFPSSamplingValid, TimeToStartClientFPSSampling);
+}
+
+bool UNFRConstants::UXMetricValid() const
+{
+	return DoValidityCheck(bUXMetricValid, TimeToStartUXMetric);
+}
+
+void UNFRConstants::InitWithWorld(const UWorld* World)
+{
+	TimeToStartPlayerCheck = FDateTime::Now().GetTicks() + FTimespan::FromSeconds(15.0f * 60.0f).GetTicks();
+	TimeToStartClientFPSSampling = FDateTime::Now().GetTicks() + FTimespan::FromSeconds(10.0f * 60.0f).GetTicks();
+	TimeToStartServerFPSSampling = FDateTime::Now().GetTicks() + FTimespan::FromSeconds(2.0f * 60.0f).GetTicks();
+	TimeToStartUXMetric = FDateTime::Now().GetTicks() + FTimespan::FromSeconds(10.0f * 60.0f).GetTicks();
 
 	USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(World->GetNetDriver());
 	// Server fps
@@ -64,7 +88,7 @@ void UNFRConstants::InitWithWorld(UWorld* World)
 	bIsInitialised = true;
 }
 
-const UNFRConstants* UNFRConstants::Get(UWorld* World)
+const UNFRConstants* UNFRConstants::Get(const UWorld* World)
 {
 	if (UGDKTestGymsGameInstance* GameInstance = World->GetGameInstance<UGDKTestGymsGameInstance>())
 	{

--- a/Game/Source/GDKTestGyms/Private/NFRConstants.cpp
+++ b/Game/Source/GDKTestGyms/Private/NFRConstants.cpp
@@ -7,15 +7,18 @@
 
 DEFINE_LOG_CATEGORY(LogNFRConstants);
 
-
 FMetricDelay::FMetricDelay()
-	: TimeToStart(0)
 {
 }
 
-FMetricDelay::FMetricDelay(int64 InTimeToStart)
-	: TimeToStart(InTimeToStart)
+FMetricDelay::FMetricDelay(int64 Seconds)
 {
+	SetDelay(Seconds);
+}
+
+void FMetricDelay::SetDelay(float Seconds)
+{
+	TimeToStart = FDateTime::Now().GetTicks() + FTimespan::FromSeconds(Seconds).GetTicks();
 }
 
 bool FMetricDelay::IsReady() const
@@ -24,10 +27,10 @@ bool FMetricDelay::IsReady() const
 }
 
 UNFRConstants::UNFRConstants()
-	: PlayerCheckMetricDelay(FDateTime::Now().GetTicks() + FTimespan::FromSeconds(15.0f * 60.0f).GetTicks())
-	, ServerFPSMetricDelay(FDateTime::Now().GetTicks() + FTimespan::FromSeconds(2.0f * 60.0f).GetTicks())
-	, ClientFPSMetricDelay(FDateTime::Now().GetTicks() + FTimespan::FromSeconds(10.0f * 60.0f).GetTicks())
-	, UXMetricDelay(FDateTime::Now().GetTicks() + FTimespan::FromSeconds(10.0f * 60.0f).GetTicks())
+	: PlayerCheckMetricDelay(15.0f * 60.0f)
+	, ServerFPSMetricDelay(2.0f * 60.0f)
+	, ClientFPSMetricDelay(10.0f * 60.0f)
+	, UXMetricDelay(10.0f * 60.0f)
 {
 }
 

--- a/Game/Source/GDKTestGyms/Private/NFRConstants.cpp
+++ b/Game/Source/GDKTestGyms/Private/NFRConstants.cpp
@@ -9,30 +9,18 @@ DEFINE_LOG_CATEGORY(LogNFRConstants);
 
 
 FMetricDelay::FMetricDelay()
-	: bIsReady(false)
-	, TimeToStart(0)
+	: TimeToStart(0)
 {
 }
 
 FMetricDelay::FMetricDelay(int64 InTimeToStart)
-	: bIsReady(false)
-	, TimeToStart(InTimeToStart)
+	: TimeToStart(InTimeToStart)
 {
 }
 
-bool FMetricDelay::IsReady()
+bool FMetricDelay::IsReady() const
 {
-	if (bIsReady)
-	{
-		return true;
-	}
-
-	if (FDateTime::Now().GetTicks() > TimeToStart)
-	{
-		bIsReady = true;
-	}
-
-	return bIsReady;
+	return FDateTime::Now().GetTicks() > TimeToStart;
 }
 
 UNFRConstants::UNFRConstants()
@@ -83,7 +71,7 @@ void UNFRConstants::InitWithWorld(const UWorld* World)
 	bIsInitialised = true;
 }
 
-UNFRConstants* UNFRConstants::Get(const UWorld* World)
+const UNFRConstants* UNFRConstants::Get(const UWorld* World)
 {
 	if (UGDKTestGymsGameInstance* GameInstance = World->GetGameInstance<UGDKTestGymsGameInstance>())
 	{

--- a/Game/Source/GDKTestGyms/Private/UserExperienceReporter.cpp
+++ b/Game/Source/GDKTestGyms/Private/UserExperienceReporter.cpp
@@ -56,6 +56,10 @@ void UUserExperienceReporter::ReportMetrics()
 		{
 			RoundTripTimeMS = CalculateAverage(UXComp->RoundTripTime);
 		}
+
+		const UWorld* World = GetWorld();
+		check(World);
+
 		// Update time delta
 		{
 			bool bValidResult = true;
@@ -65,7 +69,7 @@ void UUserExperienceReporter::ReportMetrics()
 				UUserExperienceComponent* Component = *It;
 				Component->RegisterReporter(this);
 
-				if (Component->GetOwner() && Component->HasBegunPlay() && Component->GetOwner()->GetWorld() == GetWorld())
+				if (Component->GetOwner() && Component->HasBegunPlay() && Component->GetOwner()->GetWorld() == World)
 				{
 					if (Component->UpdateRate.Num() == 0)
 					{
@@ -85,11 +89,11 @@ void UUserExperienceReporter::ReportMetrics()
 			UpdateTimeDeltaMS /= UpdateTimeDeltaCount + 0.00001f; 
 		}
 
-		if (const UGDKTestGymsGameInstance* GameInstance = Cast<UGDKTestGymsGameInstance>(GetWorld()->GetGameInstance()))
+		if (const UGDKTestGymsGameInstance* GameInstance = Cast<UGDKTestGymsGameInstance>(World->GetGameInstance()))
 		{
-			const UNFRConstants* Constants = UNFRConstants::Get(GetWorld());
+			const UNFRConstants* Constants = UNFRConstants::Get(World);
 			check(Constants);
-			if (Constants->SamplesForFPSValid() && GameInstance->GetAveragedFPS() < Constants->GetMinClientFPS())
+			if (Constants->SamplesForClientFPSValid() && GameInstance->GetAveragedFPS() < Constants->GetMinClientFPS())
 			{
 				bFrameRateValid = false;
 			}

--- a/Game/Source/GDKTestGyms/Private/UserExperienceReporter.cpp
+++ b/Game/Source/GDKTestGyms/Private/UserExperienceReporter.cpp
@@ -91,7 +91,7 @@ void UUserExperienceReporter::ReportMetrics()
 
 		if (const UGDKTestGymsGameInstance* GameInstance = Cast<UGDKTestGymsGameInstance>(World->GetGameInstance()))
 		{
-			UNFRConstants* Constants = UNFRConstants::Get(World);
+			const UNFRConstants* Constants = UNFRConstants::Get(World);
 			check(Constants);
 			if (Constants->ClientFPSMetricDelay.IsReady() && GameInstance->GetAveragedFPS() < Constants->GetMinClientFPS())
 			{

--- a/Game/Source/GDKTestGyms/Private/UserExperienceReporter.cpp
+++ b/Game/Source/GDKTestGyms/Private/UserExperienceReporter.cpp
@@ -91,9 +91,9 @@ void UUserExperienceReporter::ReportMetrics()
 
 		if (const UGDKTestGymsGameInstance* GameInstance = Cast<UGDKTestGymsGameInstance>(World->GetGameInstance()))
 		{
-			const UNFRConstants* Constants = UNFRConstants::Get(World);
+			UNFRConstants* Constants = UNFRConstants::Get(World);
 			check(Constants);
-			if (Constants->SamplesForClientFPSValid() && GameInstance->GetAveragedFPS() < Constants->GetMinClientFPS())
+			if (Constants->ClientFPSMetricDelay.IsReady() && GameInstance->GetAveragedFPS() < Constants->GetMinClientFPS())
 			{
 				bFrameRateValid = false;
 			}

--- a/Game/Source/GDKTestGyms/Public/NFRConstants.h
+++ b/Game/Source/GDKTestGyms/Public/NFRConstants.h
@@ -8,35 +8,45 @@
 
 DECLARE_LOG_CATEGORY_EXTERN(LogNFRConstants, Log, All);
 
+class FMetricDelay
+{
+public:
+
+	FMetricDelay();
+	FMetricDelay(int64 InTimeToStart);
+
+	bool IsReady();
+
+private:
+	bool bIsReady;
+	int64 TimeToStart;
+};
+
 UCLASS()
 class UNFRConstants : public UObject
 {
 public:	
+
+	UNFRConstants();
+
 	GENERATED_BODY()
 	
 	void InitWithWorld(const UWorld* World);
 
-	bool PlayerCheckValid() const;
-	bool SamplesForServerFPSValid() const; // Wait until this is true until checking Server FPS values
-	bool SamplesForClientFPSValid() const; // Wait until this is true until checking Client FPS values
-	bool UXMetricValid() const;
-
 	float GetMinServerFPS() const;
 	float GetMinClientFPS() const;
 	
-	static const UNFRConstants* Get(const UWorld* World);
+	static UNFRConstants* Get(const UWorld* World);
+
+	FMetricDelay PlayerCheckMetricDelay;
+	FMetricDelay ServerFPSMetricDelay;
+	FMetricDelay ClientFPSMetricDelay;
+	FMetricDelay UXMetricDelay;
+
 private:
+
 	bool bIsInitialised{ false };
-	int64 TimeToStartPlayerCheck;
-	int64 TimeToStartServerFPSSampling;
-	int64 TimeToStartClientFPSSampling;
-	int64 TimeToStartUXMetric;
-	mutable bool bPlayerCheckValid{ false };
-	mutable bool bServerFPSSamplingValid{ false };
-	mutable bool bClientFPSSamplingValid{ false };
-	mutable bool bUXMetricValid{ false };
+
 	float MinServerFPS = 20.0f;
 	float MinClientFPS = 20.0f;
-
-	bool DoValidityCheck(bool& IsValid, int64 TimeToStart) const;
 };

--- a/Game/Source/GDKTestGyms/Public/NFRConstants.h
+++ b/Game/Source/GDKTestGyms/Public/NFRConstants.h
@@ -15,7 +15,9 @@ public:
 	FMetricDelay();
 	FMetricDelay(int64 InTimeToStart);
 
+	void SetDelay(float Seconds);
 	bool IsReady() const;
+
 
 private:
 	int64 TimeToStart;
@@ -26,9 +28,9 @@ class UNFRConstants : public UObject
 {
 public:	
 
-	UNFRConstants();
-
 	GENERATED_BODY()
+
+	UNFRConstants();
 	
 	void InitWithWorld(const UWorld* World);
 

--- a/Game/Source/GDKTestGyms/Public/NFRConstants.h
+++ b/Game/Source/GDKTestGyms/Public/NFRConstants.h
@@ -14,18 +14,29 @@ class UNFRConstants : public UObject
 public:	
 	GENERATED_BODY()
 	
-	void InitWithWorld(UWorld* World);
+	void InitWithWorld(const UWorld* World);
 
-	bool SamplesForFPSValid() const; // Wait until this is true until checking FPS values
+	bool PlayerCheckValid() const;
+	bool SamplesForServerFPSValid() const; // Wait until this is true until checking Server FPS values
+	bool SamplesForClientFPSValid() const; // Wait until this is true until checking Client FPS values
+	bool UXMetricValid() const;
 
 	float GetMinServerFPS() const;
 	float GetMinClientFPS() const;
 	
-	static const UNFRConstants* Get(UWorld* World);
+	static const UNFRConstants* Get(const UWorld* World);
 private:
 	bool bIsInitialised{ false };
-	int64 TimeToStartFPSSampling;
-	mutable bool bFPSSamplingValid{ false };
+	int64 TimeToStartPlayerCheck;
+	int64 TimeToStartServerFPSSampling;
+	int64 TimeToStartClientFPSSampling;
+	int64 TimeToStartUXMetric;
+	mutable bool bPlayerCheckValid{ false };
+	mutable bool bServerFPSSamplingValid{ false };
+	mutable bool bClientFPSSamplingValid{ false };
+	mutable bool bUXMetricValid{ false };
 	float MinServerFPS = 20.0f;
 	float MinClientFPS = 20.0f;
+
+	bool DoValidityCheck(bool& IsValid, int64 TimeToStart) const;
 };

--- a/Game/Source/GDKTestGyms/Public/NFRConstants.h
+++ b/Game/Source/GDKTestGyms/Public/NFRConstants.h
@@ -18,7 +18,6 @@ public:
 	bool IsReady() const;
 
 private:
-	bool bIsReady;
 	int64 TimeToStart;
 };
 

--- a/Game/Source/GDKTestGyms/Public/NFRConstants.h
+++ b/Game/Source/GDKTestGyms/Public/NFRConstants.h
@@ -15,7 +15,7 @@ public:
 	FMetricDelay();
 	FMetricDelay(int64 InTimeToStart);
 
-	bool IsReady();
+	bool IsReady() const;
 
 private:
 	bool bIsReady;
@@ -36,7 +36,7 @@ public:
 	float GetMinServerFPS() const;
 	float GetMinClientFPS() const;
 	
-	static UNFRConstants* Get(const UWorld* World);
+	static const UNFRConstants* Get(const UWorld* World);
 
 	FMetricDelay PlayerCheckMetricDelay;
 	FMetricDelay ServerFPSMetricDelay;

--- a/Game/Source/GDKTestGyms/Public/NFRConstants.h
+++ b/Game/Source/GDKTestGyms/Public/NFRConstants.h
@@ -12,8 +12,8 @@ class FMetricDelay
 {
 public:
 
-	FMetricDelay();
-	FMetricDelay(int64 InTimeToStart);
+	FMetricDelay() = default;
+	FMetricDelay(float InTimeToStart);
 
 	void SetDelay(float Seconds);
 	bool IsReady() const;


### PR DESCRIPTION
This is what we want to achieve:

- In spatial we want to "fail" without any delay. This means that we will receive useful logs throughout the lifetime of a worker. We will rely on the initial delays set in NFR yaml files to ensure these metric do not fail tests too early

- In native we will not report these logs before a certain timer. This is due to the fact that the logs are used to fail NFR runs. 

All timers have been added to NFRConstants for consistency. 