### PR TITLE
UNR-3925: Use valid ip address

### DIFF
--- a/spatial/workers/improbable/spatialos.SimulatedPlayerCoordinator.worker.json
+++ b/spatial/workers/improbable/spatialos.SimulatedPlayerCoordinator.worker.json
@@ -40,7 +40,7 @@
         "${IMPROBABLE_WORKER_ID}",
         "coordinator_start_delay_millis=10000",
         
-        "connect.to.spatialos",
+        "127.0.0.1",
         "+workerType",
         "UnrealClient",
         "+deployment",


### PR DESCRIPTION
With UE 4.25 using an invalid address leads to the connection being closed. Let's use a valid IP address to fix this. we are not using this address anyway, so it can just be localhost.