### PR TITLE
UNR-4143 Add UnrealTotalAuthoritativePlayers for total players of all workers

### DIFF
--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -550,13 +550,13 @@ void ABenchmarkGymGameModeBase::SetLifetime(int32 Lifetime)
 	}
 }
 
-int ABenchmarkGymGameModeBase::GetAuthoritativePlayers()
+int ABenchmarkGymGameModeBase::GetAuthoritativePlayers() const
 {
 	int PlayerCount = 0;
 	for (FConstPlayerControllerIterator Iterator = GetWorld()->GetPlayerControllerIterator(); Iterator; ++Iterator)
 	{
 		APlayerController* PlayerActor = Iterator->Get();
-		if (PlayerActor && PlayerActor->PlayerState && !MustSpectate(PlayerActor) && PlayerActor->HasAuthority())
+		if (PlayerActor != nullptr && PlayerActor->PlayerState != nullptr && !MustSpectate(PlayerActor) && PlayerActor->HasAuthority())
 		{
 			PlayerCount++;
 		}
@@ -568,16 +568,15 @@ void ABenchmarkGymGameModeBase::ReportAuthoritativePlayers_Implementation(const 
 {
 	if (HasAuthority())
 	{
-		int& value = MapAuthoritativePlayers.FindOrAdd(WorkerID);
-		if (value != AuthoritativePlayers)
+		int& Value = MapAuthoritativePlayers.FindOrAdd(WorkerID);
+		if (Value != AuthoritativePlayers)
 		{
-			value = AuthoritativePlayers;
-			UE_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("ReportAuthoritativePlayers:%s=%d"), *WorkerID, AuthoritativePlayers);
+			Value = AuthoritativePlayers;
 		}
 	}
 }
 
-double ABenchmarkGymGameModeBase::GetTotalAuthoritativePlayers()
+double ABenchmarkGymGameModeBase::GetTotalAuthoritativePlayers() const
 {
 	double TotalPlayers = 0;
 	for (const auto& kv : MapAuthoritativePlayers)

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -186,7 +186,6 @@ void ABenchmarkGymGameModeBase::TryAddSpatialMetrics()
 					SpatialMetrics->SetCustomMetric(PlayersSpawnedMetricName, Delegate);
 				}
 
-
 				{
 					UserSuppliedMetric Delegate;
 					Delegate.BindUObject(this, &ABenchmarkGymGameModeBase::GetClientFPSValid);

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -107,13 +107,13 @@ private:
 	void TickUXMetricCheck(float DeltaSeconds);
 	void TickActorCountCheck(float DeltaSeconds);
 
-	int GetAuthoritativePlayers();
+	int GetAuthoritativePlayers() const;
 	void SetTotalNPCs(int32 Value);
 
 	double GetClientRTT() const { return AveragedClientRTTSeconds; }
 	double GetClientUpdateTimeDelta() const { return AveragedClientUpdateTimeDeltaSeconds; }
 	double GetPlayersConnected() const { return ActivePlayers; }
-	double GetTotalAuthoritativePlayers();
+	double GetTotalAuthoritativePlayers() const;
 	double GetFPSValid() const { return !bHasFpsFailed ? 1.0 : 0.0; }
 	double GetClientFPSValid() const { return !bHasClientFpsFailed ? 1.0 : 0.0; }
 	double GetActorCountValid() const { return !bActorCountFailureState ? 1.0 : 0.0; }

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -46,10 +46,6 @@ protected:
 	UPROPERTY(ReplicatedUsing = OnRepTotalNPCs, BlueprintReadWrite)
 	int32 TotalNPCs;
 
-	// Replicated so that all the workers know how many total players.
-	UPROPERTY(Replicated)
-	int32 TotalAuthoritativePlayers;
-
 	UPROPERTY(EditAnywhere, NoClear, BlueprintReadOnly, Category = Classes)
 	TSubclassOf<APawn> NPCClass;
 
@@ -73,7 +69,6 @@ protected:
 	UFUNCTION(CrossServer, Reliable)
 	virtual void ReportAuthoritativePlayers(const FString& WorkerID, int AuthoritativePlayers);
 	void ReportAuthoritativePlayers_Implementation(const FString& WorkerID, int AuthoritativePlayers);
-
 
 private:
 	// Test scenarios
@@ -118,7 +113,7 @@ private:
 	double GetClientRTT() const { return AveragedClientRTTSeconds; }
 	double GetClientUpdateTimeDelta() const { return AveragedClientUpdateTimeDeltaSeconds; }
 	double GetPlayersConnected() const { return ActivePlayers; }
-	double GetTotalAuthoritativePlayers() { return (double)TotalAuthoritativePlayers; }
+	double GetTotalAuthoritativePlayers();
 	double GetFPSValid() const { return !bHasFpsFailed ? 1.0 : 0.0; }
 	double GetClientFPSValid() const { return !bHasClientFpsFailed ? 1.0 : 0.0; }
 	double GetActorCountValid() const { return !bActorCountFailureState ? 1.0 : 0.0; }


### PR DESCRIPTION
Count all actual players of all workers.
------------------------------------
For zoning. some players would be in both workers when crossing the boundary.
If using UnrealActivePlayers and combine them together would be more then TotalPlayers.
The metrics of unrealgdk-nfr only from 1 worker. Combine all the players(HasAuthority()) of all workers is necessary.

------------------------------------
Jira ticket:https://improbableio.atlassian.net/browse/UNR-4143