### PR TITLE
UNR-4226 Change UnrealTotalAuthoritativePlayers to UnrealActivePlayers

### DIFF
--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -197,7 +197,6 @@ void ABenchmarkGymGameModeBase::Tick(float DeltaSeconds)
 	TickPlayersConnectedCheck(DeltaSeconds);
 	TickUXMetricCheck(DeltaSeconds);
 	TickActorCountCheck(DeltaSeconds);
-	ReportAuthoritativePlayers(FPlatformProcess::ComputerName(), GetAuthoritativePlayers());
 	
 	// PrintMetricsTimer needs to be reset at the the end of ABenchmarkGymGameModeBase::Tick.
 	// This is so that the above function have a chance to run logic dependant on PrintMetricsTimer.HasTimerGoneOff().
@@ -305,11 +304,6 @@ void ABenchmarkGymGameModeBase::TickClientFPSCheck(float DeltaSeconds)
 
 void ABenchmarkGymGameModeBase::TickUXMetricCheck(float DeltaSeconds)
 {
-	if (!HasAuthority())
-	{
-		return;
-	}
-
 	int UXComponentCount = 0;
 	int ValidRTTCount = 0;
 	int ValidUpdateTimeDeltaCount = 0;
@@ -332,9 +326,13 @@ void ABenchmarkGymGameModeBase::TickUXMetricCheck(float DeltaSeconds)
 				ValidUpdateTimeDeltaCount++;
 			}
 
-			UXComponentCount++;
+			if (Component->GetOwner()->HasAuthority())
+			{
+				UXComponentCount++;
+			}
 		}
 	}
+	ReportAuthoritativePlayers(FPlatformProcess::ComputerName(), UXComponentCount);
 
 	if (UXComponentCount == 0)
 	{

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -539,20 +539,6 @@ void ABenchmarkGymGameModeBase::SetLifetime(int32 Lifetime)
 	}
 }
 
-int ABenchmarkGymGameModeBase::GetAuthoritativePlayers() const
-{
-	int PlayerCount = 0;
-	for (FConstPlayerControllerIterator Iterator = GetWorld()->GetPlayerControllerIterator(); Iterator; ++Iterator)
-	{
-		APlayerController* PlayerActor = Iterator->Get();
-		if (PlayerActor != nullptr && PlayerActor->PlayerState != nullptr && !MustSpectate(PlayerActor) && PlayerActor->HasAuthority())
-		{
-			PlayerCount++;
-		}
-	}
-	return PlayerCount;
-}
-
 void ABenchmarkGymGameModeBase::ReportAuthoritativePlayers_Implementation(const FString& WorkerID, int AuthoritativePlayers)
 {
 	if (HasAuthority())

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -334,7 +334,7 @@ void ABenchmarkGymGameModeBase::TickUXMetricCheck(float DeltaSeconds)
 	}
 	ReportAuthoritativePlayers(FPlatformProcess::ComputerName(), UXComponentCount);
 
-	if (UXComponentCount == 0)
+	if (UXComponentCount == 0 || !HasAuthority())
 	{
 		return; // We don't start reporting until there are some valid components in the scene.
 	}

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -231,12 +231,12 @@ void ABenchmarkGymGameModeBase::TickPlayersConnectedCheck(float DeltaSeconds)
 		if (ActivePlayers < RequiredPlayers)
 		{
 			// This log is used by the NFR pipeline to indicate if a client failed to connect
-			NFR_LOG(LogBenchmarkGymGameModeBase, Error, TEXT("%s: Client connection dropped. Required %d, got %d"), *NFRFailureString, RequiredPlayers, ActivePlayers);
+			NFR_LOG(LogBenchmarkGymGameModeBase, Error, TEXT("%s: Client connection dropped. Required %d, got %d, num players %d"), *NFRFailureString, RequiredPlayers, ActivePlayers, GetNumPlayers());
 		}
 		else
 		{
 			// Useful for NFR log inspection
-			NFR_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("All clients successfully connected. Required %d, got %d"), RequiredPlayers, ActivePlayers);
+			NFR_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("All clients successfully connected. Required %d, got %d, num players %d"), RequiredPlayers, ActivePlayers, GetNumPlayers());
 		}
 	}
 }

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -85,14 +85,13 @@ private:
 	// bActorCountFailureState will be true if the test has failed
 	bool bActorCountFailureState;
 	bool bExpectedActorCountsInitialised;
-	int32 ActivePlayers; // A count of visible UX components
+	int32 ActivePlayers; // All authoritative players from all workers
 
 	FMetricTimer PrintMetricsTimer;
 	FMetricTimer TestLifetimeTimer;
 
 	TArray<FExpectedActorCount> ExpectedActorCounts;
 	TMap<FString, int>	MapAuthoritativePlayers;
-
 
 	virtual void BeginPlay() override;
 
@@ -112,8 +111,7 @@ private:
 
 	double GetClientRTT() const { return AveragedClientRTTSeconds; }
 	double GetClientUpdateTimeDelta() const { return AveragedClientUpdateTimeDeltaSeconds; }
-	double GetPlayersConnected() const { return ActivePlayers; }
-	double GetTotalAuthoritativePlayers() const;
+	double GetPlayersConnected() const { return (double)ActivePlayers; }
 	double GetFPSValid() const { return !bHasFpsFailed ? 1.0 : 0.0; }
 	double GetClientFPSValid() const { return !bHasClientFpsFailed ? 1.0 : 0.0; }
 	double GetActorCountValid() const { return !bActorCountFailureState ? 1.0 : 0.0; }

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -111,7 +111,7 @@ private:
 
 	double GetClientRTT() const { return AveragedClientRTTSeconds; }
 	double GetClientUpdateTimeDelta() const { return AveragedClientUpdateTimeDeltaSeconds; }
-	double GetPlayersConnected() const { return (double)ActivePlayers; }
+	double GetPlayersConnected() const { return ActivePlayers; }
 	double GetFPSValid() const { return !bHasFpsFailed ? 1.0 : 0.0; }
 	double GetClientFPSValid() const { return !bHasClientFpsFailed ? 1.0 : 0.0; }
 	double GetActorCountValid() const { return !bActorCountFailureState ? 1.0 : 0.0; }

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -106,7 +106,6 @@ private:
 	void TickUXMetricCheck(float DeltaSeconds);
 	void TickActorCountCheck(float DeltaSeconds);
 
-	int GetAuthoritativePlayers() const;
 	void SetTotalNPCs(int32 Value);
 
 	double GetClientRTT() const { return AveragedClientRTTSeconds; }

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -110,7 +110,7 @@ private:
 
 	double GetClientRTT() const { return AveragedClientRTTSeconds; }
 	double GetClientUpdateTimeDelta() const { return AveragedClientUpdateTimeDeltaSeconds; }
-	double GetPlayersConnected() const { return ActivePlayers; }
+	double GetPlayersConnected() const { return static_cast<double>(ActivePlayers); }
 	double GetFPSValid() const { return !bHasFpsFailed ? 1.0 : 0.0; }
 	double GetClientFPSValid() const { return !bHasClientFpsFailed ? 1.0 : 0.0; }
 	double GetActorCountValid() const { return !bActorCountFailureState ? 1.0 : 0.0; }


### PR DESCRIPTION
To keep the nfr testing with the same expectations both on zoning and none-zoning.
Add a new metric is not necessary.
------------------------------------------
Count the authoritative players from UUserExperienceReporter with HasAuthority() check.
GetNumPlayers() is necessary for analyzing the log of UnrealWorker, So I restore it back.

Jira ticket:
https://improbableio.atlassian.net/browse/UNR-4226