### PR TITLE
UNR-4045 Add UnrealActorMigration as a new metric for zoning-nfr 

### DIFF
--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -75,7 +75,7 @@ ABenchmarkGymGameModeBase::ABenchmarkGymGameModeBase()
 	, MigrationCountSeconds(0.0)
 	, MigrationWindowSeconds(5*60.0f)
 	, MinActorMigrationPerSecond(0.0)
-	, ActorMigrationCheckTimer(6*60) // 1-minute later then UNFRConstants::ActorMigrationCheckDelay to make sure all the workers had reported their migration
+	, ActorMigrationCheckTimer(11*60) // 1-minute later then UNFRConstants::ActorMigrationCheckDelay + MigrationWindowSeconds to make sure all the workers had reported their migration
 	, ActivePlayerReportDelayTimer(5*60)
 	, PrintMetricsTimer(10)
 	, TestLifetimeTimer(0)

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -606,9 +606,8 @@ void ABenchmarkGymGameModeBase::TickActorMigration(float DeltaSeconds)
 		if (MigrationCountSeconds > MigrationWindowSeconds)
 		{
 			MigrationDeltaPair OldestValue;
-			if (MigrationDeltaHistory.Peek(OldestValue))
+			if (MigrationDeltaHistory.Dequeue(OldestValue))
 			{
-				MigrationDeltaHistory.Pop();
 				MigrationOfCurrentWorker -= OldestValue.Key;
 				MigrationSeconds -= OldestValue.Value;
 				bChanged = (Delta != OldestValue.Key);

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -5,7 +5,6 @@
 #include "CounterComponent.h"
 #include "Engine/World.h"
 #include "EngineClasses/SpatialNetDriver.h"
-#include "GameFramework/Character.h"
 #include "GameFramework/GameStateBase.h"
 #include "GameFramework/MovementComponent.h"
 #include "GDKTestGymsGameInstance.h"
@@ -38,7 +37,7 @@ namespace
 	const FString TestLiftimeWorkerFlag = TEXT("test_lifetime");
 	const FString TestLiftimeCommandLineKey = TEXT("-TestLifetime=");
 
-	const FString HandOverTotalFrameCountWorkerFlag = TEXT("HandOver_total_frame_count");
+	const FString HandOverTotalFrameCountWorkerFlag = TEXT("handover_total_frame_count");
 	const FString TotalPlayerWorkerFlag = TEXT("total_players");
 	const FString TotalNPCsWorkerFlag = TEXT("total_npcs");
 	const FString RequiredPlayersWorkerFlag = TEXT("required_players");
@@ -70,7 +69,7 @@ ABenchmarkGymGameModeBase::ABenchmarkGymGameModeBase()
 	, LastTimeHandOverActors(0)
 	, HandOverdActorsOfCurrentWorker(0)
 	, HandOverFrameCount(0)
-	, HandOverTotalFrameCount(9000)
+	, HandOverTotalFrameCount(9000) // About 5Mins(FPS=30 on worker)
 	, PrintMetricsTimer(10)
 	, TestLifetimeTimer(0)
 {
@@ -621,6 +620,5 @@ double ABenchmarkGymGameModeBase::GetTotalHandOverActors() const
 	{
 		TotalHandOverActors += kv.Value;
 	}
-	UE_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("TotalHandOverActors=%d"), TotalHandOverActors);
 	return static_cast<double>(TotalHandOverActors);
 }

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -626,6 +626,7 @@ void ABenchmarkGymGameModeBase::TickActorMigration(float DeltaSeconds)
 			}
 		}
 		MigrationOfCurrentWorker += Delta;
+		MigrationExactlyWindowSeconds += DeltaSeconds;
 		PreviousTickMigration = UXAuthActorCount;
 
 		if (MigrationCountSeconds > MigrationWindowSeconds)
@@ -649,15 +650,15 @@ void ABenchmarkGymGameModeBase::TickActorMigration(float DeltaSeconds)
 					if (AverageActorMigration < MinActorMigrationPerSecond)
 					{
 						bHasActorMigrationCheckFailed = true;
-						NFR_LOG(LogBenchmarkGymGameModeBase, Error, TEXT("%s: Actor migration check failed. TotalMigrations=%.3f AverageActorMigration=%.3f MinActorMigration=%.3f"),
-							*NFRFailureString, TotalMigrations, AverageActorMigration, MinActorMigrationPerSecond);
+						NFR_LOG(LogBenchmarkGymGameModeBase, Error, TEXT("%s: Actor migration check failed. TotalMigrations=%.3f AverageActorMigration=%.3f MinActorMigration=%.3f MigrationExactlyWindowSeconds=%.3f"),
+							*NFRFailureString, TotalMigrations, AverageActorMigration, MinActorMigrationPerSecond, MigrationExactlyWindowSeconds);
 					}
 					else
 					{
 						// reset timer for next check after 10s
 						ActorMigrationCheckTimer.SetTimer(10);
-						UE_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("Actor migration check TotalMigrations=%.3f AverageActorMigration=%.3f MinActorMigration=%.3f"),
-							TotalMigrations, AverageActorMigration, MinActorMigrationPerSecond);
+						UE_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("Actor migration check TotalMigrations=%.3f AverageActorMigration=%.3f MinActorMigration=%.3f MigrationExactlyWindowSeconds=%.3f"),
+							TotalMigrations, AverageActorMigration, MinActorMigrationPerSecond, MigrationExactlyWindowSeconds);
 					}
 				}
 			}

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -618,7 +618,7 @@ void ABenchmarkGymGameModeBase::TickActorMigration(float DeltaSeconds)
 
 		if (MigrationCountSeconds > MigrationWindowSeconds)
 		{
-			// Only report MigratedActorsOfCurrentWorker to the worker which has authority and the Migration changed
+			// Only report AverageMigrationOfCurrentWorkerPerSecond to the worker which has authority
 			float AverageMigrationOfCurrentWorkerPerSecond = MigrationOfCurrentWorker / MigrationSeconds;
 			ReportMigration(FPlatformProcess::ComputerName(), AverageMigrationOfCurrentWorkerPerSecond);
 

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -575,29 +575,23 @@ void ABenchmarkGymGameModeBase::ReportAuthoritativePlayers_Implementation(const 
 void ABenchmarkGymGameModeBase::TickActorHandOver(float DeltaSeconds)
 {
 	// Count how many actors hand over authority in 1 tick
-	int AuthMovingActors = GetAuthMovingActors();
-	int Delta = FMath::Abs(AuthMovingActors - LastTimeHandOverActors);
+	int MovementAuthActors = GetMovementAuthActors();
+	int Delta = FMath::Abs(MovementAuthActors - LastTimeHandOverActors);
 	ToBeRemovedHandOverActors.Push(Delta);
 	if (HandOverFrameCount > HandOverTotalFrameCount)
 	{
 		int RemoveValue = ToBeRemovedHandOverActors.Pop(true);
 		HandOverdActorsOfCurrentWorker -= RemoveValue;
-		//UE_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("RemoveValue=%d"), RemoveValue);
 	}
 	HandOverdActorsOfCurrentWorker += Delta;
-	if (Delta > 0)
-	{
-		UE_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("Delta=%d,HandOverdActorsOfCurrentWorker=%d,AuthMovingActors=%d,LastTimeHandOverActors=%d"),
-			Delta, HandOverdActorsOfCurrentWorker, AuthMovingActors, LastTimeHandOverActors);
-	}
-	LastTimeHandOverActors = AuthMovingActors;
+	LastTimeHandOverActors = MovementAuthActors;
 	++HandOverFrameCount;
 
 	// Report HandOverdActorsOfCurrentWorker to the worker which has authority
 	ReportHandOverActors(FPlatformProcess::ComputerName(), HandOverdActorsOfCurrentWorker);
 }
 
-int ABenchmarkGymGameModeBase::GetAuthMovingActors() const
+int ABenchmarkGymGameModeBase::GetMovementAuthActors() const
 {
 	int TotalAuthMovingActors = 0;
 	for (TObjectIterator<UMovementComponent> Itr; Itr; ++Itr)

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -579,9 +579,9 @@ void ABenchmarkGymGameModeBase::ReportAuthoritativePlayers_Implementation(const 
 	{
 		MapAuthoritativePlayers.Emplace(WorkerID, AuthoritativePlayers);
 		ActivePlayers = 0;
-		for (const auto& kv : MapAuthoritativePlayers)
+		for (const auto& KeyValue : MapAuthoritativePlayers)
 		{
-			ActivePlayers += kv.Value;
+			ActivePlayers += KeyValue.Value;
 		}
 	}
 }
@@ -610,7 +610,6 @@ void ABenchmarkGymGameModeBase::TickActorMigration(float DeltaSeconds)
 			{
 				MigrationOfCurrentWorker -= OldestValue.Key;
 				MigrationSeconds -= OldestValue.Value;
-				bChanged = (Delta != OldestValue.Key);
 			}
 		}
 		MigrationOfCurrentWorker += Delta;
@@ -619,12 +618,9 @@ void ABenchmarkGymGameModeBase::TickActorMigration(float DeltaSeconds)
 
 		if (MigrationCountSeconds > MigrationWindowSeconds)
 		{
-			if (bChanged)
-			{
-				// Only report MigratedActorsOfCurrentWorker to the worker which has authority and the Migration changed
-				float AverageMigrationOfCurrentWorker = MigrationOfCurrentWorker / MigrationSeconds;
-				ReportMigration(FPlatformProcess::ComputerName(), AverageMigrationOfCurrentWorker);
-			}
+			// Only report MigratedActorsOfCurrentWorker to the worker which has authority and the Migration changed
+			float AverageMigrationOfCurrentWorkerPerSecond = MigrationOfCurrentWorker / MigrationSeconds;
+			ReportMigration(FPlatformProcess::ComputerName(), AverageMigrationOfCurrentWorkerPerSecond);
 
 			if (HasAuthority() && ActorMigrationCheckTimer.HasTimerGoneOff())
 			{

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -643,14 +643,14 @@ void ABenchmarkGymGameModeBase::TickActorMigration(float DeltaSeconds)
 					if (AverageActorMigration < MinActorMigrationPerSecond)
 					{
 						bHasActorMigrationCheckFailed = true;
-						NFR_LOG(LogBenchmarkGymGameModeBase, Error, TEXT("%s: Actor migration check failed. TotalMigrations=%.3f AverageActorMigration=%.3f MinActorMigration=%.3f MigrationExactlyWindowSeconds=%.3f"),
+						NFR_LOG(LogBenchmarkGymGameModeBase, Error, TEXT("%s: Actor migration check failed. TotalMigrations=%.3f AverageActorMigration=%.3f MinActorMigrationPerSecond=%.3f MigrationExactlyWindowSeconds=%.3f"),
 							*NFRFailureString, TotalMigrations, AverageActorMigration, MinActorMigrationPerSecond, MigrationSeconds);
 					}
 					else
 					{
 						// Reset timer for next check after 10s
 						ActorMigrationCheckTimer.SetTimer(10);
-						UE_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("Actor migration check TotalMigrations=%.3f AverageActorMigration=%.3f MinActorMigration=%.3f MigrationExactlyWindowSeconds=%.3f"),
+						UE_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("Actor migration check TotalMigrations=%.3f AverageActorMigration=%.3f MinActorMigrationPerSecond=%.3f MigrationExactlyWindowSeconds=%.3f"),
 							TotalMigrations, AverageActorMigration, MinActorMigrationPerSecond, MigrationSeconds);
 					}
 				}

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -70,7 +70,7 @@ protected:
 	virtual void ReportAuthoritativePlayers(const FString& WorkerID, const int AuthoritativePlayers);
 
 	UFUNCTION(CrossServer, Reliable)
-	virtual void ReportMigration(const FString& WorkerID, const int Migration);
+	virtual void ReportMigration(const FString& WorkerID, const float AverageMigration);
 private:
 	// Test scenarios
 
@@ -91,14 +91,14 @@ private:
 	// For actor migration count
 	bool bHasActorMigrationCheckFailed;
 	int32 PreviousTickMigration;
-	TQueue<int32> ToBeRemovedMigrationDeltas;
-	TQueue<float> ToBeRemovedDeltaSeconds;
+	typedef TTuple<int32, float> ToBeRemovedDelta;
+	TQueue<ToBeRemovedDelta> ToBeRemovedMigrationDeltas;
 	int32 UXAuthActorCount;
 	int32 MigrationOfCurrentWorker;
-	float MigrationExactlyWindowSeconds;
+	float MigrationSeconds;
 	float MigrationCountSeconds;
 	float MigrationWindowSeconds;
-	TMap<FString, int32>	MapWorkerActorMigration;
+	TMap<FString, float> MapWorkerActorMigration;
 	float MinActorMigrationPerSecond;
 	FMetricTimer ActorMigrationCheckTimer;
 

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -91,10 +91,12 @@ private:
 	// For actor migration count
 	bool bHasActorMigrationCheckFailed;
 	int32 PreviousTickMigration;
-	TArray<int32> ToBeRemovedMigrationDeltas;
+	TQueue<int32> ToBeRemovedMigrationDeltas;
+	TQueue<float> ToBeRemovedDeltaSeconds;
 	int32 UXAuthActorCount;
 	int32 MigrationOfCurrentWorker;
-	float MingrationCountSeconds;
+	float MigrationExactlyWindowSeconds;
+	float MigrationCountSeconds;
 	float MigrationWindowSeconds;
 	TMap<FString, int32>	MapWorkerActorMigration;
 	float MinActorMigrationPerSecond;

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -94,10 +94,10 @@ private:
 	TArray<int32> ToBeRemovedMigrationDeltas;
 	int32 UXAuthActorCount;
 	int32 MigrationOfCurrentWorker;
-	int32 MigrationFrameCount;
-	int32 MigrationWindowFrameCount;
+	float MingrationCountSeconds;
+	float MigrationWindowSeconds;
 	TMap<FString, int32>	MapWorkerActorMigration;
-	float MinActorMigration;
+	float MinActorMigrationPerSecond;
 	FMetricTimer ActorMigrationCheckTimer;
 
 	FMetricTimer PrintMetricsTimer;

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -92,11 +92,12 @@ private:
 	bool bHasActorMigrationCheckFailed;
 	int32 PreviousTickMigration;
 	TArray<int32> ToBeRemovedMigrationDeltas;
+	int32 UXAuthActorCount;
 	int32 MigrationOfCurrentWorker;
 	int32 MigrationFrameCount;
 	int32 MigrationWindowFrameCount;
 	TMap<FString, int32>	MapWorkerActorMigration;
-	double MinActorMigration;
+	float MinActorMigration;
 	FMetricTimer ActorMigrationCheckTimer;
 
 	FMetricTimer PrintMetricsTimer;
@@ -119,7 +120,6 @@ private:
 	void TickActorCountCheck(float DeltaSeconds);
 	void TickActorMigration(float DeltaSeconds);
 
-	int GetMovementAuthActors() const;
 	void SetTotalNPCs(int32 Value);
 
 	double GetClientRTT() const { return AveragedClientRTTSeconds; }

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -91,8 +91,8 @@ private:
 	// For actor migration count
 	bool bHasActorMigrationCheckFailed;
 	int32 PreviousTickMigration;
-	typedef TTuple<int32, float> ToBeRemovedDelta;
-	TQueue<ToBeRemovedDelta> ToBeRemovedMigrationDeltas;
+	typedef TTuple<int32, float> MigrationDeltaPair;
+	TQueue<MigrationDeltaPair> ToBeRemovedMigrationDeltas;
 	int32 UXAuthActorCount;
 	int32 MigrationOfCurrentWorker;
 	float MigrationSeconds;

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -96,7 +96,7 @@ private:
 	int32 MigrationFrameCount;
 	int32 MigrationWindowFrameCount;
 	TMap<FString, int32>	MapWorkerActorMigration;
-	int32 MinActorMigration;
+	double MinActorMigration;
 	FMetricTimer ActorMigrationCheckTimer;
 
 	FMetricTimer PrintMetricsTimer;

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -70,6 +70,9 @@ protected:
 	virtual void ReportAuthoritativePlayers(const FString& WorkerID, int AuthoritativePlayers);
 	void ReportAuthoritativePlayers_Implementation(const FString& WorkerID, int AuthoritativePlayers);
 
+	UFUNCTION(CrossServer, Reliable)
+	virtual void ReportHandOverActors(const FString& WorkerID, int HandOverActors);
+	void ReportHandOverActors_Implementation(const FString& WorkerID, int HandOverActors);
 private:
 	// Test scenarios
 
@@ -86,6 +89,14 @@ private:
 	bool bActorCountFailureState;
 	bool bExpectedActorCountsInitialised;
 	int32 ActivePlayers; // All authoritative players from all workers
+
+	// For hand over authoritative actors count
+	int LastTimeHandOverActors;
+	TArray<int> ToBeRemovedHandOverActors;
+	int TotalHandOverdActorsOfCurrentWorker;
+	int HandOverFrameCount;
+	int HandOverTotalFrameCount;
+	TMap<FString, int>	MapHandOverActors;
 
 	FMetricTimer PrintMetricsTimer;
 	FMetricTimer TestLifetimeTimer;
@@ -105,12 +116,16 @@ private:
 	void TickClientFPSCheck(float DeltaSeconds);
 	void TickUXMetricCheck(float DeltaSeconds);
 	void TickActorCountCheck(float DeltaSeconds);
+	void TickActorHandOver(float DeltaSeconds);
 
+	int GetAuthoritativePlayers() const;
+	int GetAuthoritativeActors() const;
 	void SetTotalNPCs(int32 Value);
 
 	double GetClientRTT() const { return AveragedClientRTTSeconds; }
 	double GetClientUpdateTimeDelta() const { return AveragedClientUpdateTimeDeltaSeconds; }
 	double GetPlayersConnected() const { return static_cast<double>(ActivePlayers); }
+	double GetTotalHandOverActors() const;
 	double GetFPSValid() const { return !bHasFpsFailed ? 1.0 : 0.0; }
 	double GetClientFPSValid() const { return !bHasClientFpsFailed ? 1.0 : 0.0; }
 	double GetActorCountValid() const { return !bActorCountFailureState ? 1.0 : 0.0; }

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -93,7 +93,7 @@ private:
 	// For hand over authoritative actors count
 	int LastTimeHandOverActors;
 	TArray<int> ToBeRemovedHandOverActors;
-	int TotalHandOverdActorsOfCurrentWorker;
+	int HandOverdActorsOfCurrentWorker;
 	int HandOverFrameCount;
 	int HandOverTotalFrameCount;
 	TMap<FString, int>	MapHandOverActors;
@@ -118,8 +118,7 @@ private:
 	void TickActorCountCheck(float DeltaSeconds);
 	void TickActorHandOver(float DeltaSeconds);
 
-	int GetAuthoritativePlayers() const;
-	int GetAuthoritativeActors() const;
+	int GetAuthMovingActors() const;
 	void SetTotalNPCs(int32 Value);
 
 	double GetClientRTT() const { return AveragedClientRTTSeconds; }

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -89,12 +89,15 @@ private:
 	int32 ActivePlayers; // All authoritative players from all workers
 
 	// For actor migration count
+	bool bHasActorMigrationCheckFailed;
 	int32 PreviousTickMigration;
-	TArray<int32> ToBeRemovedMigration;
+	TArray<int32> ToBeRemovedMigrationDeltas;
 	int32 MigrationOfCurrentWorker;
 	int32 MigrationFrameCount;
 	int32 MigrationWindowFrameCount;
 	TMap<FString, int32>	MapWorkerActorMigration;
+	int32 MinActorMigration;
+	FMetricTimer ActorMigrationCheckTimer;
 
 	FMetricTimer PrintMetricsTimer;
 	FMetricTimer TestLifetimeTimer;
@@ -122,7 +125,7 @@ private:
 	double GetClientRTT() const { return AveragedClientRTTSeconds; }
 	double GetClientUpdateTimeDelta() const { return AveragedClientUpdateTimeDeltaSeconds; }
 	double GetPlayersConnected() const { return static_cast<double>(ActivePlayers); }
-	double GetTotalMigrations() const;
+	double GetTotalMigrationValid() const { return !bHasActorMigrationCheckFailed ? 1.0 : 0.0; }
 	double GetFPSValid() const { return !bHasFpsFailed ? 1.0 : 0.0; }
 	double GetClientFPSValid() const { return !bHasClientFpsFailed ? 1.0 : 0.0; }
 	double GetActorCountValid() const { return !bActorCountFailureState ? 1.0 : 0.0; }

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -118,7 +118,7 @@ private:
 	void TickActorCountCheck(float DeltaSeconds);
 	void TickActorHandOver(float DeltaSeconds);
 
-	int GetAuthMovingActors() const;
+	int GetMovementAuthActors() const;
 	void SetTotalNPCs(int32 Value);
 
 	double GetClientRTT() const { return AveragedClientRTTSeconds; }

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -67,12 +67,10 @@ protected:
 	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const;
 
 	UFUNCTION(CrossServer, Reliable)
-	virtual void ReportAuthoritativePlayers(const FString& WorkerID, int AuthoritativePlayers);
-	void ReportAuthoritativePlayers_Implementation(const FString& WorkerID, int AuthoritativePlayers);
+	virtual void ReportAuthoritativePlayers(const FString& WorkerID, const int AuthoritativePlayers);
 
 	UFUNCTION(CrossServer, Reliable)
-	virtual void ReportHandOverActors(const FString& WorkerID, int HandOverActors);
-	void ReportHandOverActors_Implementation(const FString& WorkerID, int HandOverActors);
+	virtual void ReportMigration(const FString& WorkerID, const int Migration);
 private:
 	// Test scenarios
 
@@ -90,13 +88,13 @@ private:
 	bool bExpectedActorCountsInitialised;
 	int32 ActivePlayers; // All authoritative players from all workers
 
-	// For hand over authoritative actors count
-	int LastTimeHandOverActors;
-	TArray<int> ToBeRemovedHandOverActors;
-	int HandOverdActorsOfCurrentWorker;
-	int HandOverFrameCount;
-	int HandOverTotalFrameCount;
-	TMap<FString, int>	MapHandOverActors;
+	// For actor migration count
+	int32 PreviousTickMigration;
+	TArray<int32> ToBeRemovedMigration;
+	int32 MigrationOfCurrentWorker;
+	int32 MigrationFrameCount;
+	int32 MigrationWindowFrameCount;
+	TMap<FString, int32>	MapWorkerActorMigration;
 
 	FMetricTimer PrintMetricsTimer;
 	FMetricTimer TestLifetimeTimer;
@@ -116,7 +114,7 @@ private:
 	void TickClientFPSCheck(float DeltaSeconds);
 	void TickUXMetricCheck(float DeltaSeconds);
 	void TickActorCountCheck(float DeltaSeconds);
-	void TickActorHandOver(float DeltaSeconds);
+	void TickActorMigration(float DeltaSeconds);
 
 	int GetMovementAuthActors() const;
 	void SetTotalNPCs(int32 Value);
@@ -124,7 +122,7 @@ private:
 	double GetClientRTT() const { return AveragedClientRTTSeconds; }
 	double GetClientUpdateTimeDelta() const { return AveragedClientUpdateTimeDeltaSeconds; }
 	double GetPlayersConnected() const { return static_cast<double>(ActivePlayers); }
-	double GetTotalHandOverActors() const;
+	double GetTotalMigrations() const;
 	double GetFPSValid() const { return !bHasFpsFailed ? 1.0 : 0.0; }
 	double GetClientFPSValid() const { return !bHasClientFpsFailed ? 1.0 : 0.0; }
 	double GetActorCountValid() const { return !bActorCountFailureState ? 1.0 : 0.0; }

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -92,7 +92,7 @@ private:
 	bool bHasActorMigrationCheckFailed;
 	int32 PreviousTickMigration;
 	typedef TTuple<int32, float> MigrationDeltaPair;
-	TQueue<MigrationDeltaPair> ToBeRemovedMigrationDeltas;
+	TQueue<MigrationDeltaPair> MigrationDeltaHistory;
 	int32 UXAuthActorCount;
 	int32 MigrationOfCurrentWorker;
 	float MigrationSeconds;
@@ -101,7 +101,8 @@ private:
 	TMap<FString, float> MapWorkerActorMigration;
 	float MinActorMigrationPerSecond;
 	FMetricTimer ActorMigrationCheckTimer;
-
+	
+	FMetricTimer ActivePlayerReportDelayTimer;
 	FMetricTimer PrintMetricsTimer;
 	FMetricTimer TestLifetimeTimer;
 

--- a/Game/Source/GDKTestGyms/Private/NFRConstants.cpp
+++ b/Game/Source/GDKTestGyms/Private/NFRConstants.cpp
@@ -47,6 +47,7 @@ UNFRConstants::UNFRConstants()
 	, ClientFPSMetricDelay(60)
 	, UXMetricDelay(10 * 60)
 	, ActorCheckDelay(10 * 60)
+	, ActorMigrationCheckDelay(5 * 60)
 {
 }
 

--- a/Game/Source/GDKTestGyms/Public/NFRConstants.h
+++ b/Game/Source/GDKTestGyms/Public/NFRConstants.h
@@ -48,6 +48,7 @@ public:
 	FMetricTimer ClientFPSMetricDelay;
 	FMetricTimer UXMetricDelay;
 	FMetricTimer ActorCheckDelay;
+	FMetricTimer ActorMigrationCheckDelay;
 
 private:
 


### PR DESCRIPTION
For zoning specific overhead, add a new metric UnrealActorMigration.
1) Count all the Actors which HasAuthority() in each tick
2) Calculate the delta with the count of the last frame
3) sum all the abs of delta in 5 minutes as MigrationOfCurrentWorker
4) sum all the MigrationOfCurrentWorker from all workers as the value of the metric

Added a new WorkerFlag that changes how Migration is verified and prints the associated logs in case of failure.
Changed Migration to every frame instead of the previous every 9000 frames.
Added DelayTimer to avoid statistical errors caused by the players not being fully connected.
Changed the reporting of Migration to only for changes.