### PR TITLE
fix long debug record compilation issues

### DIFF
--- a/Game/Source/GDKTestGyms/GDKTestGyms.Build.cs
+++ b/Game/Source/GDKTestGyms/GDKTestGyms.Build.cs
@@ -6,6 +6,7 @@ public class GDKTestGyms : ModuleRules
 {
 	public GDKTestGyms(ReadOnlyTargetRules Target) : base(Target)
 	{
+		bLegacyPublicIncludePaths = false;
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		PublicDependencyModuleNames.AddRange(

--- a/Game/Source/GDKTestGyms/GDKTestGymsCharacter.cpp
+++ b/Game/Source/GDKTestGyms/GDKTestGymsCharacter.cpp
@@ -9,7 +9,7 @@
 #include "GameFramework/Controller.h"
 #include "GameFramework/SpringArmComponent.h"
 #include "Kismet/GameplayStatics.h"
-#include "SpatialNetDriver.h"
+#include "EngineClasses/SpatialNetDriver.h"
 
 #include "UnrealNetwork.h"
 

--- a/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.cpp
+++ b/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.cpp
@@ -5,7 +5,7 @@
 #include "Interop/Connection/SpatialConnectionManager.h"
 
 #include "NFRConstants.h"
-#include "SpatialNetDriver.h"
+#include "EngineClasses/SpatialNetDriver.h"
 #include "Utils/SpatialMetrics.h"
 
 #include "GeneralProjectSettings.h"

--- a/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.h
+++ b/Game/Source/GDKTestGyms/GDKTestGymsGameInstance.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "NFRConstants.h"
-#include "SpatialGameInstance.h"
+#include "EngineClasses/SpatialGameInstance.h"
 
 #include "CoreMinimal.h"
 #include "Engine/NetDriver.h"

--- a/Game/Source/GDKTestGyms/Private/NFRConstants.cpp
+++ b/Game/Source/GDKTestGyms/Private/NFRConstants.cpp
@@ -2,7 +2,7 @@
 
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineUtils.h"
-#include "GDKTestGymsGameInstance.h"
+#include "GDKTestGyms/GDKTestGymsGameInstance.h"
 #include "Interop/SpatialWorkerFlags.h"
 
 DEFINE_LOG_CATEGORY(LogNFRConstants);

--- a/Game/Source/GDKTestGyms/Private/UserExperienceComponent.cpp
+++ b/Game/Source/GDKTestGyms/Private/UserExperienceComponent.cpp
@@ -5,7 +5,7 @@
 #include "UserExperienceReporter.h"
 
 #include "Net/UnrealNetwork.h"
-#include "SpatialNetDriver.h"
+#include "EngineClasses/SpatialNetDriver.h"
 #include "Utils/SpatialMetrics.h"
 
 DEFINE_LOG_CATEGORY(LogUserExperienceComponent);

--- a/Game/Source/GDKTestGyms/Private/UserExperienceReporter.cpp
+++ b/Game/Source/GDKTestGyms/Private/UserExperienceReporter.cpp
@@ -3,10 +3,10 @@
 
 #include "UserExperienceReporter.h"
 
-#include "GDKTestGymsGameInstance.h"
+#include "GDKTestGyms/GDKTestGymsGameInstance.h"
 #include "NFRConstants.h"
 #include "Net/UnrealNetwork.h"
-#include "SpatialNetDriver.h"
+#include "EngineClasses/SpatialNetDriver.h"
 #include "UserExperienceComponent.h"
 #include "Utils/SpatialMetrics.h"
 


### PR DESCRIPTION
had a bunch of problems with building the GDK test gyms because of this legacy property thing. This PR cleans up includes such that we can turn it off, and then also turns it off. I no longer get "debug compilation record too long" errors when compiling now. (at least, so far)