### PR TITLE
UNR-4426 fix connected clients expectation synchronization issue

### DIFF
--- a/Game/Source/GDKTestGyms/BenchmarkGymGameMode.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameMode.h
@@ -51,7 +51,6 @@ private:
 	TMap<int32, AActor*> PlayerIdToSpawnPointMap;
 	TSubclassOf<AActor> DropCubeClass;
 	int32 NPCSToSpawn;
-	int32 NumWorkers;
 
 	UPROPERTY()
 	ABenchmarkGymNPCSpawner* NPCSpawner;

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -607,7 +607,7 @@ void ABenchmarkGymGameModeBase::ReportAuthoritativePlayers_Implementation(const 
 			}
 			else
 			{
-				SmoothedTotalAuthPlayers = (SmoothedTotalAuthPlayers + TotalPlayers) * 0.5f;
+				SmoothedTotalAuthPlayers = SmoothedTotalAuthPlayers * 0.9f + TotalPlayers * 0.1;
 			}
 			UE_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("ReportAuthoritativePlayers(%s, %d) Total:%.1f"),
 				*WorkerID, AuthoritativePlayers, SmoothedTotalAuthPlayers);

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -361,7 +361,7 @@ void ABenchmarkGymGameModeBase::TickUXMetricCheck(float DeltaSeconds)
 
 	if (RequiredPlayerReportTimer.HasTimerGoneOff())
 	{
-		// We don't start reporting until PlayerCheckMetricDelay has gone off
+		// We don't start reporting until RequiredPlayerReportTimer has gone off
 		ReportAuthoritativePlayers(FPlatformProcess::ComputerName(), UXAuthActorCount);
 		RequiredPlayerReportTimer.SetTimer(1);
 	}

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -70,7 +70,9 @@ protected:
 	virtual void ReportAuthoritativePlayers(const FString& WorkerID, const int AuthoritativePlayers);
 
 	UFUNCTION(CrossServer, Reliable)
-	virtual void ReportMigration(const FString& WorkerID, const float AverageMigration);
+	virtual void ReportMigration(const FString& WorkerID, const float Migration);
+
+	int32 GetNumWorkers() const { return NumWorkers; }
 private:
 	// Test scenarios
 
@@ -80,13 +82,11 @@ private:
 	int32 MaxClientUpdateTimeDeltaMS;
 	bool bHasUxFailed;
 	bool bHasFpsFailed;
-	bool bHasDonePlayerCheck;
 	bool bHasClientFpsFailed;
 	bool bHasActorCountFailed;
 	// bActorCountFailureState will be true if the test has failed
 	bool bActorCountFailureState;
 	bool bExpectedActorCountsInitialised;
-	int32 ActivePlayers; // All authoritative players from all workers
 
 	// For actor migration count
 	bool bHasActorMigrationCheckFailed;
@@ -100,14 +100,23 @@ private:
 	float MigrationWindowSeconds;
 	TMap<FString, float> MapWorkerActorMigration;
 	float MinActorMigrationPerSecond;
+	FMetricTimer ActorMigrationReportTimer;
 	FMetricTimer ActorMigrationCheckTimer;
+	FMetricTimer ActorMigrationCheckDelay;
 	
-	FMetricTimer ActivePlayerReportDelayTimer;
 	FMetricTimer PrintMetricsTimer;
 	FMetricTimer TestLifetimeTimer;
 
 	TArray<FExpectedActorCount> ExpectedActorCounts;
 	TMap<FString, int>	MapAuthoritativePlayers;
+
+	// For total player
+	bool bHasRequiredPlayersCheckFailed;
+	float AveragedTotalAuthPlayers;
+	FMetricTimer RequiredPlayerReportTimer;
+	FMetricTimer RequiredPlayerCheckTimer;
+	
+	int32 NumWorkers;
 
 	virtual void BeginPlay() override;
 
@@ -127,7 +136,7 @@ private:
 
 	double GetClientRTT() const { return AveragedClientRTTMS; }
 	double GetClientUpdateTimeDelta() const { return AveragedClientUpdateTimeDeltaMS; }
-	double GetPlayersConnected() const { return static_cast<double>(ActivePlayers); }
+	double GetRequiredPlayersValid() const { return !bHasRequiredPlayersCheckFailed ? 1.0 : 0.0; }
 	double GetTotalMigrationValid() const { return !bHasActorMigrationCheckFailed ? 1.0 : 0.0; }
 	double GetFPSValid() const { return !bHasFpsFailed ? 1.0 : 0.0; }
 	double GetClientFPSValid() const { return !bHasClientFpsFailed ? 1.0 : 0.0; }

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -112,7 +112,7 @@ private:
 
 	// For total player
 	bool bHasRequiredPlayersCheckFailed;
-	float AveragedTotalAuthPlayers;
+	float SmoothedTotalAuthPlayers;
 	FMetricTimer RequiredPlayerReportTimer;
 	FMetricTimer RequiredPlayerCheckTimer;
 	

--- a/Game/Source/GDKTestGyms/Private/NFRConstants.cpp
+++ b/Game/Source/GDKTestGyms/Private/NFRConstants.cpp
@@ -42,12 +42,10 @@ int32 FMetricTimer::GetSecondsRemaining() const
 
 
 UNFRConstants::UNFRConstants()
-	: PlayerCheckMetricDelay(10 * 60)
-	, ServerFPSMetricDelay(60)
+	: ServerFPSMetricDelay(60)
 	, ClientFPSMetricDelay(60)
 	, UXMetricDelay(10 * 60)
 	, ActorCheckDelay(10 * 60)
-	, ActorMigrationCheckDelay(5 * 60)
 {
 }
 

--- a/Game/Source/GDKTestGyms/Public/NFRConstants.h
+++ b/Game/Source/GDKTestGyms/Public/NFRConstants.h
@@ -43,12 +43,10 @@ public:
 	
 	static const UNFRConstants* Get(const UWorld* World);
 
-	FMetricTimer PlayerCheckMetricDelay;
 	FMetricTimer ServerFPSMetricDelay;
 	FMetricTimer ClientFPSMetricDelay;
 	FMetricTimer UXMetricDelay;
 	FMetricTimer ActorCheckDelay;
-	FMetricTimer ActorMigrationCheckDelay;
 
 private:
 


### PR DESCRIPTION
Sometimes, there are some 1 or 2 clients lost in the max-player scenario of zoning-NFR. 
After investigating the client_stayed_connection issue. I found the value of total players on all the workers is not a stable value.
As the picture is shown on the [ticket](https://improbableio.atlassian.net/browse/UNR-4426).
So we decide to change the total player number as an average value for the last frame and the current frame.
It should very approach the value we expected. 
Sometimes it was 1.xx less than expectation. So we set the expectation of max-player as 2.

BTW:
1. Change the player number check to a valid check. So we can have the same value of expectation with BuildKite.
2. Change the timer for the delay, check and report. to make sure when we start to check, the worker has enough time to prepare the simulate players and reduce the frequency of RPC of when report.
3. Change the migration to total migration, not for a single worker.