### PR TITLE
UNR-4427 enable stat profile via workerflag

### DIFF
--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -256,7 +256,6 @@ void ABenchmarkGymGameModeBase::Tick(float DeltaSeconds)
 			FString FileName = FString::Format(TEXT("stat startfile {0}.ue4stats"), { SpatialDriver->Connection->GetWorkerId() });
 			GEngine->Exec(GetWorld(), *FileName);
 			StatStartFileTimer.SetTimer(999999);
-			StatStopFileTimer.SetTimer(3 * 60);
 		}
 	}
 	if (StatStopFileTimer.HasTimerGoneOff())

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -253,7 +253,7 @@ void ABenchmarkGymGameModeBase::Tick(float DeltaSeconds)
 		USpatialNetDriver* SpatialDriver = Cast<USpatialNetDriver>(GetNetDriver());
 		if (ensure(SpatialDriver != nullptr))
 		{
-			FString FileName = FString::Format(TEXT("stat startfile ../../../../../../improbable/logs/UnrealWorker/{0}.ue4stats"), { SpatialDriver->Connection->GetWorkerId() });
+			FString FileName = FString::Format(TEXT("stat startfile {0}.ue4stats"), { SpatialDriver->Connection->GetWorkerId() });
 			GEngine->Exec(GetWorld(), *FileName);
 			StatStartFileTimer.SetTimer(999999);
 			StatStopFileTimer.SetTimer(3 * 60);

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -49,10 +49,10 @@ namespace
 	
 	const FString NumWorkersWorkerFlag = TEXT("num_workers");
 	const FString NumWorkersCommandLineKey = TEXT("-NumWorkers=");
-
+#if	STATS
 	const FString StatProfileWorkerFlag = TEXT("stat_profile");
 	const FString StatProfileCommandLineKey = TEXT("-StatProfile=");
-
+#endif
 	const FString NFRFailureString = TEXT("NFR scenario failed");
 
 } // anonymous namespace
@@ -90,8 +90,10 @@ ABenchmarkGymGameModeBase::ABenchmarkGymGameModeBase()
 	, RequiredPlayerCheckTimer(11*60) // 1-minute later then RequiredPlayerReportTimer to make sure all the workers had reported their migration
 	, DeploymentValidTimer(16*60) // 16-minute window to check between
 	, NumWorkers(1)
+#if	STATS
 	, StatStartFileTimer(60 * 60 * 24)
 	, StatStopFileTimer(60)
+#endif
 {
 	PrimaryActorTick.bCanEverTick = true;
 
@@ -244,22 +246,27 @@ void ABenchmarkGymGameModeBase::Tick(float DeltaSeconds)
 	{
 		PrintMetricsTimer.SetTimer(10);
 	}
-	
+#if	STATS
 	if (StatStartFileTimer.HasTimerGoneOff())
 	{
-		USpatialNetDriver* SpatialDriver = Cast<USpatialNetDriver>(GetNetDriver());
-		if (ensure(SpatialDriver != nullptr))
+		FString Cmd(TEXT("stat startfile"));
+		if (GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking())
 		{
-			FString FileName = FString::Format(TEXT("stat startfile {0}.ue4stats"), { SpatialDriver->Connection->GetWorkerId() });
-			GEngine->Exec(GetWorld(), *FileName);
-			StatStartFileTimer.SetTimer(999999);
+			USpatialNetDriver* SpatialDriver = Cast<USpatialNetDriver>(GetNetDriver());
+			if (ensure(SpatialDriver != nullptr))
+			{
+				Cmd = FString::Printf(TEXT("stat startfile %s.ue4stats"), *SpatialDriver->Connection->GetWorkerId());
+			}
 		}
+		GEngine->Exec(GetWorld(), *Cmd);
+		StatStartFileTimer.SetTimer(999999);
 	}
 	if (StatStopFileTimer.HasTimerGoneOff())
 	{
 		GEngine->Exec(GetWorld(), TEXT("stat stopfile"));
 		StatStopFileTimer.SetTimer(999999);
 	}
+#endif
 }
 
 void ABenchmarkGymGameModeBase::TickPlayersConnectedCheck(float DeltaSeconds)
@@ -484,10 +491,12 @@ void ABenchmarkGymGameModeBase::ParsePassedValues()
 		FParse::Value(*CommandLine, *MaxUpdateTimeDeltaCommandLineKey, MaxClientUpdateTimeDeltaMS);
 		FParse::Value(*CommandLine, *MinActorMigrationCommandLineKey, MinActorMigrationPerSecond);
 		FParse::Value(*CommandLine, *NumWorkersCommandLineKey, NumWorkers);
-
+		
+#if	STATS
 		FString StatProfileString;
 		FParse::Value(*CommandLine, *StatProfileCommandLineKey, StatProfileString);
-		
+		SetStatTimer(StatProfileString);
+#endif
 	}
 	else if (GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking())
 	{
@@ -539,12 +548,13 @@ void ABenchmarkGymGameModeBase::ParsePassedValues()
 				{
 					NumWorkers = FCString::Atoi(*NumWorkersString);
 				}
-
+#if	STATS
 				FString StatProfileString;
 				if (SpatialWorkerFlags->GetWorkerFlag(StatProfileWorkerFlag, StatProfileString))
 				{
 					SetStatTimer(StatProfileString);
 				}
+#endif
 			}
 		}
 	}
@@ -586,10 +596,12 @@ void ABenchmarkGymGameModeBase::OnWorkerFlagUpdated(const FString& FlagName, con
 	{
 		NumWorkers = FCString::Atof(*FlagValue);
 	}
+#if	STATS
 	else if (FlagName == StatProfileWorkerFlag)
 	{
 		SetStatTimer(FlagValue);
 	}
+#endif
 
 	UE_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("Worker flag updated - Flag %s, Value %s"), *FlagName, *FlagValue);
 }
@@ -725,7 +737,7 @@ void ABenchmarkGymGameModeBase::ReportMigration_Implementation(const FString& Wo
 		MapWorkerActorMigration.Emplace(WorkerID, Migration);
 	}
 }
-
+#if	STATS
 void ABenchmarkGymGameModeBase::SetStatTimer(const FString& TimeString)
 {
 	FString StartDelayString, DurationString;
@@ -737,3 +749,4 @@ void ABenchmarkGymGameModeBase::SetStatTimer(const FString& TimeString)
 		StatStopFileTimer.SetTimer(StartDelay + Duration);
 	}
 }
+#endif

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -119,6 +119,10 @@ private:
 	
 	int32 NumWorkers;
 
+	// For stat profile
+	FMetricTimer StatStartFileTimer;
+	FMetricTimer StatStopFileTimer;
+
 	virtual void BeginPlay() override;
 
 	void TryInitialiseExpectedActorCounts();
@@ -144,6 +148,8 @@ private:
 	double GetActorCountValid() const { return !bActorCountFailureState ? 1.0 : 0.0; }
 
 	void SetLifetime(int32 Lifetime);
+
+	void SetStatStartStopTime(int32 StartDelayTime, int32 StopDelayTime);
 
 	UFUNCTION()
 	void OnRepTotalNPCs();

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -6,7 +6,6 @@
 #include "GameFramework/GameModeBase.h"
 #include "UserExperienceReporter.h"
 #include "NFRConstants.h"
-
 #include "BenchmarkGymGameModeBase.generated.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogBenchmarkGymGameModeBase, Log, All);
@@ -118,10 +117,11 @@ private:
 	FMetricTimer DeploymentValidTimer;
 	
 	int32 NumWorkers;
-
+#if	STATS
 	// For stat profile
 	FMetricTimer StatStartFileTimer;
 	FMetricTimer StatStopFileTimer;
+#endif
 
 	virtual void BeginPlay() override;
 
@@ -148,8 +148,9 @@ private:
 	double GetActorCountValid() const { return !bActorCountFailureState ? 1.0 : 0.0; }
 
 	void SetLifetime(int32 Lifetime);
-
+#if	STATS
 	void SetStatTimer(const FString& TimeString);
+#endif
 
 	UFUNCTION()
 	void OnRepTotalNPCs();

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -149,7 +149,7 @@ private:
 
 	void SetLifetime(int32 Lifetime);
 
-	void SetStatStartStopTime(int32 StartDelayTime, int32 StopDelayTime);
+	void SetStatTimer(const FString& TimeString);
 
 	UFUNCTION()
 	void OnRepTotalNPCs();


### PR DESCRIPTION
For CPU usage investigating, we can enable the Unreal stat profile via WorkerFlag.
`start_profile_after_beginning` means how long `stat startfile` after game beginning in seconds.
`stop_profile_after_startfile` means how long `stat stopfile` after `stat startfile` in seconds.
Also, support the command line with `StartProfileAfterBeginning` and `StopProfileAfterStartfile` as the same as above.
The output stat file path is `data\workers\UnrealWorker\GDKTestGyms\Saved\Profiling\UnrealStats` and the file name is base on WorkerId.

Jira ticket:https://improbableio.atlassian.net/browse/UNR-4475
Successful build:https://buildkite.com/improbable/unrealgdk-nfr/builds/3194
