### PR TITLE
Fixing flake in NFRs to do with player count

### DIFF
--- a/Game/Source/GDKTestGyms/BenchmarkGymGameMode.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameMode.cpp
@@ -215,11 +215,13 @@ void ABenchmarkGymGameMode::GenerateSpawnPointClusters(int NumClusters)
 {
 	const int DistBetweenClusterCenters = 40000; // 400 meters, in Unreal units.
 
+	int32 NumSpawnZones = GetNumSpawnZones();
+
 	// We use a fixed size 10km
-	const float ZoneWidth = 1000000.0f / GetNumWorkers();
+	const float ZoneWidth = 1000000.0f / NumSpawnZones;
 	const float StartingX = -500000.0f;
 
-	if (GetNumWorkers() > 1)
+	if (NumSpawnZones > 1)
 	{
 		// For multiworker configuration we will place a percentage of spawn points
 		// on/near the boundary between two zones
@@ -227,7 +229,7 @@ void ABenchmarkGymGameMode::GenerateSpawnPointClusters(int NumClusters)
 		int RemainingClusters = NumClusters - ClustersOnBoundaries;
 
 		TArray<float> Boundaries;
-		for (int i = 1; i < GetNumWorkers(); ++i)
+		for (int i = 1; i < NumSpawnZones; ++i)
 		{
 			Boundaries.Emplace(StartingX + ZoneWidth * i);
 		}
@@ -252,8 +254,8 @@ void ABenchmarkGymGameMode::GenerateSpawnPointClusters(int NumClusters)
 		NumClusters = RemainingClusters;
 	}
 
-	int ClustersPerWorker = FMath::CeilToInt(NumClusters / static_cast<float>(GetNumWorkers()));
-	for (int w = 0; w < GetNumWorkers(); ++w)
+	int ClustersPerWorker = FMath::CeilToInt(NumClusters / static_cast<float>(NumSpawnZones));
+	for (int w = 0; w < NumSpawnZones; ++w)
 	{
 		int ClusterCount = FMath::Min(ClustersPerWorker, NumClusters);
 		NumClusters -= ClusterCount;

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameMode.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameMode.cpp
@@ -215,13 +215,13 @@ void ABenchmarkGymGameMode::GenerateSpawnPointClusters(int NumClusters)
 {
 	const int DistBetweenClusterCenters = 40000; // 400 meters, in Unreal units.
 
-	int32 NumSpawnZones = GetNumSpawnZones();
+	const int32 SpawnZones = GetNumSpawnZones();
 
 	// We use a fixed size 10km
-	const float ZoneWidth = 1000000.0f / NumSpawnZones;
+	const float ZoneWidth = 1000000.0f / SpawnZones;
 	const float StartingX = -500000.0f;
 
-	if (NumSpawnZones > 1)
+	if (SpawnZones > 1)
 	{
 		// For multiworker configuration we will place a percentage of spawn points
 		// on/near the boundary between two zones
@@ -229,7 +229,7 @@ void ABenchmarkGymGameMode::GenerateSpawnPointClusters(int NumClusters)
 		int RemainingClusters = NumClusters - ClustersOnBoundaries;
 
 		TArray<float> Boundaries;
-		for (int i = 1; i < NumSpawnZones; ++i)
+		for (int i = 1; i < SpawnZones; ++i)
 		{
 			Boundaries.Emplace(StartingX + ZoneWidth * i);
 		}
@@ -254,8 +254,8 @@ void ABenchmarkGymGameMode::GenerateSpawnPointClusters(int NumClusters)
 		NumClusters = RemainingClusters;
 	}
 
-	int ClustersPerWorker = FMath::CeilToInt(NumClusters / static_cast<float>(NumSpawnZones));
-	for (int w = 0; w < NumSpawnZones; ++w)
+	int ClustersPerWorker = FMath::CeilToInt(NumClusters / static_cast<float>(SpawnZones));
+	for (int w = 0; w < SpawnZones; ++w)
 	{
 		int ClusterCount = FMath::Min(ClustersPerWorker, NumClusters);
 		NumClusters -= ClusterCount;

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -49,6 +49,9 @@ namespace
 	
 	const FString NumWorkersWorkerFlag = TEXT("num_workers");
 	const FString NumWorkersCommandLineKey = TEXT("-NumWorkers=");
+
+	const FString NumSpawnZonesWorkerFlag = TEXT("num_spawn_zones");
+	const FString NumSpawnZonesCommandLineKey = TEXT("-NumSpawnZones=");
 #if	STATS
 	const FString StatProfileWorkerFlag = TEXT("stat_profile");
 	const FString StatProfileCommandLineKey = TEXT("-StatProfile=");
@@ -88,8 +91,9 @@ ABenchmarkGymGameModeBase::ABenchmarkGymGameModeBase()
 	, SmoothedTotalAuthPlayers(-1.0f)
 	, RequiredPlayerReportTimer(10 * 60)
 	, RequiredPlayerCheckTimer(11*60) // 1-minute later then RequiredPlayerReportTimer to make sure all the workers had reported their migration
-	, DeploymentValidTimer(14.5*60) // 14.5-minute window to check between
+	, DeploymentValidTimer(16*60) // 16-minute window to check between
 	, NumWorkers(1)
+	, NumSpawnZones(1)
 #if	STATS
 	, StatStartFileTimer(60 * 60 * 24)
 	, StatStopFileTimer(60)
@@ -491,6 +495,7 @@ void ABenchmarkGymGameModeBase::ParsePassedValues()
 		FParse::Value(*CommandLine, *MaxUpdateTimeDeltaCommandLineKey, MaxClientUpdateTimeDeltaMS);
 		FParse::Value(*CommandLine, *MinActorMigrationCommandLineKey, MinActorMigrationPerSecond);
 		FParse::Value(*CommandLine, *NumWorkersCommandLineKey, NumWorkers);
+		FParse::Value(*CommandLine, *NumSpawnZonesCommandLineKey, NumSpawnZones);
 		
 #if	STATS
 		FString StatProfileString;
@@ -501,7 +506,7 @@ void ABenchmarkGymGameModeBase::ParsePassedValues()
 	else if (GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking())
 	{
 		UE_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("Using worker flags to load custom spawning parameters."));
-		FString ExpectedPlayersString, RequiredPlayersString, TotalNPCsString, MaxRoundTrip, MaxUpdateTimeDelta, LifetimeString, MinActorMigrationString, NumWorkersString;
+		FString ExpectedPlayersString, RequiredPlayersString, TotalNPCsString, MaxRoundTrip, MaxUpdateTimeDelta, LifetimeString, MinActorMigrationString, NumWorkersString, NumSpawnZonesString;
 
 		USpatialNetDriver* SpatialDriver = Cast<USpatialNetDriver>(GetNetDriver());
 		if (ensure(SpatialDriver != nullptr))
@@ -548,6 +553,11 @@ void ABenchmarkGymGameModeBase::ParsePassedValues()
 				{
 					NumWorkers = FCString::Atoi(*NumWorkersString);
 				}
+
+				if (SpatialWorkerFlags->GetWorkerFlag(NumSpawnZonesWorkerFlag, NumSpawnZonesString))
+				{
+					NumSpawnZones = FCString::Atoi(*NumSpawnZonesString);
+				}
 #if	STATS
 				FString StatProfileString;
 				if (SpatialWorkerFlags->GetWorkerFlag(StatProfileWorkerFlag, StatProfileString))
@@ -559,7 +569,8 @@ void ABenchmarkGymGameModeBase::ParsePassedValues()
 		}
 	}
 
-	UE_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("Players %d, NPCs %d, RoundTrip %d, UpdateTimeDelta %d, MinActorMigrationPerSecond %.8f, NumWorkers %d"), ExpectedPlayers, TotalNPCs, MaxClientRoundTripMS, MaxClientUpdateTimeDeltaMS, MinActorMigrationPerSecond, NumWorkers);
+	UE_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("Players %d, NPCs %d, RoundTrip %d, UpdateTimeDelta %d, MinActorMigrationPerSecond %.8f, NumWorkers %d, NumSpawnZones %d"), 
+		ExpectedPlayers, TotalNPCs, MaxClientRoundTripMS, MaxClientUpdateTimeDeltaMS, MinActorMigrationPerSecond, NumWorkers, NumSpawnZones);
 }
 
 void ABenchmarkGymGameModeBase::OnAnyWorkerFlagUpdated(const FString& FlagName, const FString& FlagValue)
@@ -595,6 +606,10 @@ void ABenchmarkGymGameModeBase::OnAnyWorkerFlagUpdated(const FString& FlagName, 
 	else if (FlagName == NumWorkersWorkerFlag)
 	{
 		NumWorkers = FCString::Atof(*FlagValue);
+	}
+	else if (FlagName == NumSpawnZonesWorkerFlag)
+	{
+		NumSpawnZones = FCString::Atof(*FlagValue);
 	}
 #if	STATS
 	else if (FlagName == StatProfileWorkerFlag)

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -88,7 +88,7 @@ ABenchmarkGymGameModeBase::ABenchmarkGymGameModeBase()
 	, SmoothedTotalAuthPlayers(-1.0f)
 	, RequiredPlayerReportTimer(10 * 60)
 	, RequiredPlayerCheckTimer(11*60) // 1-minute later then RequiredPlayerReportTimer to make sure all the workers had reported their migration
-	, DeploymentValidTimer(14.5*60) // 16-minute window to check between
+	, DeploymentValidTimer(14.5*60) // 14.5-minute window to check between
 	, NumWorkers(1)
 #if	STATS
 	, StatStartFileTimer(60 * 60 * 24)

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -88,7 +88,7 @@ ABenchmarkGymGameModeBase::ABenchmarkGymGameModeBase()
 	, SmoothedTotalAuthPlayers(-1.0f)
 	, RequiredPlayerReportTimer(10 * 60)
 	, RequiredPlayerCheckTimer(11*60) // 1-minute later then RequiredPlayerReportTimer to make sure all the workers had reported their migration
-	, DeploymentValidTimer(16*60) // 16-minute window to check between
+	, DeploymentValidTimer(14.5*60) // 16-minute window to check between
 	, NumWorkers(1)
 #if	STATS
 	, StatStartFileTimer(60 * 60 * 24)

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -72,6 +72,7 @@ protected:
 	virtual void ReportMigration(const FString& WorkerID, const float Migration);
 
 	int32 GetNumWorkers() const { return NumWorkers; }
+	int32 GetNumSpawnZones() const { return NumSpawnZones; }
 private:
 	// Test scenarios
 
@@ -117,6 +118,7 @@ private:
 	FMetricTimer DeploymentValidTimer;
 	
 	int32 NumWorkers;
+	int32 NumSpawnZones;
 #if	STATS
 	// For stat profile
 	FMetricTimer StatStartFileTimer;


### PR DESCRIPTION
Using "NumSpawnZones" to distribute spawn clusters. This is just to ensure we have parity between offloaded, non offloaded and native tests.

NFRBuildkite PR: https://github.com/improbable/TestGymBuildkite/pull/219

BK Test: https://buildkite.com/improbable/unrealgdk-nfr/builds/3544