### PR TITLE
UNR-4874 Count auth PlayerController for client_stayed_connection check

### DIFF
--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -399,7 +399,7 @@ void ABenchmarkGymGameModeBase::TickUXMetricCheck(float DeltaSeconds)
 	if (RequiredPlayerReportTimer.HasTimerGoneOff())
 	{
 		// We don't start reporting until RequiredPlayerReportTimer has gone off
-		ReportAuthoritativePlayers(FPlatformProcess::ComputerName(), UXAuthActorCount);
+		ReportAuthoritativePlayers(FPlatformProcess::ComputerName(), GetPlayerControllerCount());
 		RequiredPlayerReportTimer.SetTimer(1);
 	}
 
@@ -765,3 +765,19 @@ void ABenchmarkGymGameModeBase::SetStatTimer(const FString& TimeString)
 	}
 }
 #endif
+
+int32 ABenchmarkGymGameModeBase::GetPlayerControllerCount()
+{
+	int32 Count = 0;
+	for (FConstPlayerControllerIterator PCIt = GetWorld()->GetPlayerControllerIterator(); PCIt; ++PCIt)
+	{
+		if (APlayerController* PC = PCIt->Get())
+		{
+			if (PC->HasAuthority())
+			{
+				++Count;
+			}
+		}
+	}
+	return Count;
+}

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -766,7 +766,7 @@ void ABenchmarkGymGameModeBase::SetStatTimer(const FString& TimeString)
 }
 #endif
 
-int32 ABenchmarkGymGameModeBase::GetPlayerControllerCount()
+int32 ABenchmarkGymGameModeBase::GetPlayerControllerCount() const
 {
 	int32 Count = 0;
 	for (FConstPlayerControllerIterator PCIt = GetWorld()->GetPlayerControllerIterator(); PCIt; ++PCIt)

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -150,6 +150,7 @@ private:
 	double GetActorCountValid() const { return !bActorCountFailureState ? 1.0 : 0.0; }
 
 	void SetLifetime(int32 Lifetime);
+	int32 GetPlayerControllerCount();
 #if	STATS
 	void SetStatTimer(const FString& TimeString);
 #endif

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -150,7 +150,7 @@ private:
 	double GetActorCountValid() const { return !bActorCountFailureState ? 1.0 : 0.0; }
 
 	void SetLifetime(int32 Lifetime);
-	int32 GetPlayerControllerCount();
+	int32 GetPlayerControllerCount() const;
 #if	STATS
 	void SetStatTimer(const FString& TimeString);
 #endif


### PR DESCRIPTION
We count the PlayerCharacter which has `UUserExperienceReporter` as the expectation of client_stayed_connection before, as the understanding updated, we think to count the PlayerController as the expectation should be better for us to know the connection count, not the actor count.

The successful build is:https://buildkite.com/improbable/unrealgdk-nfr/builds/3564
the old branch of the test is out-to-date, this PR just `merge --squash` from that branch