### PR TITLE
Add missing header

### DIFF
--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -9,6 +9,7 @@
 #include "GameFramework/MovementComponent.h"
 #include "GDKTestGymsGameInstance.h"
 #include "GeneralProjectSettings.h"
+#include "Interop/Connection/SpatialWorkerConnection.h"
 #include "Interop/SpatialWorkerFlags.h"
 #include "Misc/CommandLine.h"
 #include "Net/UnrealNetwork.h"


### PR DESCRIPTION
Fix that is required by https://github.com/spatialos/UnrealGDK/pull/2965, which cleans up the SpatialNetDriver header with more forward declarations.