### PR TITLE
[Fix] Shut down Memreport Flag in Shipping build

### DIFF
--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -56,10 +56,10 @@ namespace
 #if	STATS
 	const FString StatProfileWorkerFlag = TEXT("stat_profile");
 	const FString StatProfileCommandLineKey = TEXT("-StatProfile=");
-#endif
+
 	const FString MemReportFlag = TEXT("mem_report");
 	const FString MemRemportIntervalKey = TEXT("-Interval=");
-
+#endif
 	const FString NFRFailureString = TEXT("NFR scenario failed");
 
 } // anonymous namespace
@@ -101,8 +101,8 @@ ABenchmarkGymGameModeBase::ABenchmarkGymGameModeBase()
 #if	STATS
 	, StatStartFileTimer(60 * 60 * 24)
 	, StatStopFileTimer(60)
+	, MemReportIntervalTimer(60 * 60 * 24)
 #endif
-	,MemReportIntervalTimer(60 * 60 * 24)
 {
 	PrimaryActorTick.bCanEverTick = true;
 
@@ -275,7 +275,7 @@ void ABenchmarkGymGameModeBase::Tick(float DeltaSeconds)
 		GEngine->Exec(GetWorld(), TEXT("stat stopfile"));
 		StatStopFileTimer.SetTimer(999999);
 	}
-#endif
+
 	if (MemReportInterval > 0 && MemReportIntervalTimer.HasTimerGoneOff())
 	{
 		FString Cmd = TEXT("memreport -full");
@@ -290,6 +290,7 @@ void ABenchmarkGymGameModeBase::Tick(float DeltaSeconds)
 		GEngine->Exec(nullptr, *Cmd);
 		MemReportIntervalTimer.SetTimer(MemReportInterval);
 	}
+#endif
 }
 
 void ABenchmarkGymGameModeBase::TickPlayersConnectedCheck(float DeltaSeconds)
@@ -520,10 +521,11 @@ void ABenchmarkGymGameModeBase::ParsePassedValues()
 		FString StatProfileString;
 		FParse::Value(*CommandLine, *StatProfileCommandLineKey, StatProfileString);
 		SetStatTimer(StatProfileString);
-#endif
+
 		FString MemReportIntervalString;
 		FParse::Value(*CommandLine, *MemRemportIntervalKey, MemReportIntervalString);
 		InitMemReportTimer(MemReportIntervalString);
+#endif
 	}
 	else if (GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking())
 	{
@@ -586,12 +588,13 @@ void ABenchmarkGymGameModeBase::ParsePassedValues()
 				{
 					SetStatTimer(StatProfileString);
 				}
-#endif
+
 				FString MemReportIntervalString;
 				if (SpatialWorkerFlags->GetWorkerFlag(MemReportFlag,MemReportIntervalString))
 				{
 					InitMemReportTimer(MemReportIntervalString);
 				}
+#endif
 			}
 		}
 	}
@@ -643,12 +646,11 @@ void ABenchmarkGymGameModeBase::OnAnyWorkerFlagUpdated(const FString& FlagName, 
 	{
 		SetStatTimer(FlagValue);
 	}
-#endif
 	else if (FlagName == MemReportFlag)
 	{
 		InitMemReportTimer(FlagValue);
 	}
-
+#endif
 	UE_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("Worker flag updated - Flag %s, Value %s"), *FlagName, *FlagValue);
 }
 
@@ -795,7 +797,6 @@ void ABenchmarkGymGameModeBase::SetStatTimer(const FString& TimeString)
 		StatStopFileTimer.SetTimer(StartDelay + Duration);
 	}
 }
-#endif
 
 void ABenchmarkGymGameModeBase::InitMemReportTimer(const FString& MemReportIntervalString)
 {
@@ -803,6 +804,7 @@ void ABenchmarkGymGameModeBase::InitMemReportTimer(const FString& MemReportInter
 	MemReportIntervalTimer.SetTimer(MemReportInterval);
 	UE_LOG(LogBenchmarkGymGameModeBase, Log, TEXT("MemReport Interval is set to %d seconds"), MemReportInterval);
 }
+#endif
 
 int32 ABenchmarkGymGameModeBase::GetPlayerControllerCount() const
 {

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -124,11 +124,10 @@ private:
 	// For stat profile
 	FMetricTimer StatStartFileTimer;
 	FMetricTimer StatStopFileTimer;
-#endif
-
 	//For MemReport profile
 	int32 MemReportInterval;
 	FMetricTimer MemReportIntervalTimer;
+#endif
 
 	virtual void BeginPlay() override;
 


### PR DESCRIPTION
put all the flag codes into STATS macro to fix compile error and avoid the extra Tick() cost in shipping.
waiting for NFR test: https://buildkite.com/improbable/unrealgdk-nfr/builds/4120