### PR TITLE
Disable Magic Leap plugins + Obsolete VR inputs plugins that were triggering WARNs

### DIFF
--- a/Game/Config/DefaultInput.ini
+++ b/Game/Config/DefaultInput.ini
@@ -22,4 +22,3 @@
 +AxisMappings=(AxisName="LookUp", Key=MouseY, Scale=-1.f)
 
 +ActionMappings=(ActionName="ResetVR", Key=R)
-+ActionMappings=(ActionName="ResetVR",Key=MotionController_Left_Grip1,bShift=False,bCtrl=False,bAlt=False,bCmd=False)

--- a/Game/GDKTestGyms.uproject
+++ b/Game/GDKTestGyms.uproject
@@ -30,6 +30,42 @@
 		{
 			"Name": "SteamVR",
 			"Enabled": false
+		},
+		{
+			"Name": "MagicLeapMedia",
+			"Enabled": false,
+			"SupportedTargetPlatforms": [
+				"Lumin"
+			]
+		},
+		{
+			"Name": "MagicLeap",
+			"Enabled": false,
+			"SupportedTargetPlatforms": [
+				"Lumin",
+				"Mac",
+				"Win64"
+			]
+		},
+		{
+			"Name": "MagicLeapPassableWorld",
+			"Enabled": false,
+			"SupportedTargetPlatforms": [
+				"Lumin",
+				"Mac",
+				"Win64"
+			]
+		},
+		{
+			"Name": "LuminPlatformFeatures",
+			"Enabled": false,
+			"SupportedTargetPlatforms": [
+				"Lumin"
+			]
+		},
+		{
+			"Name": "MLSDK",
+			"Enabled": false
 		}
 	]
 }


### PR DESCRIPTION
* I made the plugin changes via the **Edit** > **Plugins** flow. I didn't manually edit the `.uproject` file.
  * These changes non-destructively disable Magic Leap.
  * They stop these errors triggering when you open the project or generate schema:
`Warning: MLSDK not found.  This likely means the MLSDK environment variable is not set.`
`Warning: VR disabled because ZI is not enabled.`
* I tested these before and after making the changes.
* I also deleted `+ActionMappings=(ActionName="ResetVR",Key=MotionController_Left_Grip1,bShift=False,bCtrl=False,bAlt=False,bCmd=False)`
  * Because it was triggering:
  * `LogInput: Warning: Action ResetVR uses invalid key MotionController_Left_Grip1.`
  * `LogInput: Warning: Use -RemoveInvalidKeys to remove instances of these keys from the action mapping.`

