### PR TITLE
Fix labels and messages. Make new ci required. 

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -35,10 +35,11 @@ steps:
   # New build pipeline
   # Trigger a 4.26 build
   - trigger: "unrealgdkbuild-ci"
-    label: "testgyms-ci-426 ${BUILDKITE_MESSAGE}"
-    async: true
+    label: "testgyms-ci-4.26"
+    async: false
     build:
       branch: *ci_version
+      message: "testgyms-4.26 ${BUILDKITE_MESSAGE}"
       env: 
         BUILD_TYPE: "GDK"
         GDK_BRANCH: "master" # TODO: Do we want auto-branch name detection?
@@ -53,10 +54,11 @@ steps:
 
   # Trigger a 4.25 build
   - trigger: "unrealgdkbuild-ci"
-    label: "testgyms-ci-425 ${BUILDKITE_MESSAGE}"
-    async: true
+    label: "testgyms-ci-4.25"
+    async: false
     build: 
       branch: *ci_version
+      message: "testgyms-4.25 ${BUILDKITE_MESSAGE}"
       env: 
         BUILD_TYPE: "GDK"
         GDK_BRANCH: "master" # TODO: Do we want auto-branch name detection?


### PR DESCRIPTION
Labels are used to identify which builds are required by GH. By generating unique labels for each branch we were spamming our GH UI with new builds to watch and also made it impossible to make the old-ci non-required without removing it. This fixes that.