### PR TITLE
Fix "The config file will be staged, but is not whitelisted or blacklisted" WARNs

### DIFF
--- a/Game/Config/DefaultGame.ini
+++ b/Game/Config/DefaultGame.ini
@@ -16,3 +16,12 @@ MaxSpectators=1000
 
 [/Script/GameplayAbilities.AbilitySystemGlobals]
 +GameplayCueNotifyPaths="/Game"
+
+[Staging]
++WhitelistConfigFiles=GDKTestGyms/Config/DefaultSpatialGDKEditorSettings.ini
++WhitelistConfigFiles=GDKTestGyms/Config/DefaultSpatialGDKSettings.ini
++WhitelistConfigFiles=GDKTestGyms/Config/MapSettingsOverrides/TestOverridesBase.ini
++WhitelistConfigFiles=GDKTestGyms/Config/MapSettingsOverrides/TestOverridesOneClientGroup.ini
++WhitelistConfigFiles=GDKTestGyms/Config/MapSettingsOverrides/TestOverridesSpatialEventTracingGroup.ini
++WhitelistConfigFiles=GDKTestGyms/Config/MapSettingsOverrides/TestOverridesSpatialSnapshotTestPart1Map.ini
++WhitelistConfigFiles=GDKTestGyms/Config/MapSettingsOverrides/TestOverridesSpatialSnapshotTestPart2Map.ini


### PR DESCRIPTION
#### Description
Modified `DefaultGame.ini` to whitelist files that were previously throwing WARNs when building assemblies for cloud deployments.

#### Release note
None.

#### Tests
* I cloud deployed after I implemented this fix in order to ensure that I hadn't broken that functionality.
* I confirmed that the WARNs are gone.

#### Documentation
Not needed.

#### Primary reviewers
@mironec