### PR TITLE
Update USER_MANUAL.md

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -370,6 +370,7 @@ These test whether key trace events have the appropriate cause events. They can 
 
 ##### Multiworker World Composition gym
 * Tests that servers without authoritive player controllers are still able to replicate relevant actors.
+* Please note that when you run this test gym, you man notice the cubes moving discontinuously (that is, juddering or stuttering rather than moving smoothly). This is expected and should not be considered a defect. This occurs because, by default, with Replication Graph turned on, actors are only updated every third tick.
 * Manual steps:
   * Before booting the Unreal Editor, open `UnrealGDKTestGyms\Game\Config\DefaultEngine.ini` and uncomment the `ReplicationDriverClassName` option by deleing the `;`.
   * Boot the Unreal Editor.


### PR DESCRIPTION
* Uncommenting `ReplicationDriverClassName` activates the Replication Graph.
* The Replication Graph's `GridSpatialization2D` node contains `ActorListFrequencyBuckets`, which by default have 3 buckets of actors, and sends updates to only one bucket per tick.
* This results in the cubes in the gym being updates every third tick, which causes them to move discontinuously (visually stuttering).
* This setting can be tweaked, but it is not in this gym.
* This note simply explains to users that they should not worry about the discontinuous motion of the cubes.