### PR TITLE
Remove old CLI flags from test override 

### DIFF
--- a/Game/Config/MapSettingsOverrides/TestOverridesSpatialEventTracingTests.ini
+++ b/Game/Config/MapSettingsOverrides/TestOverridesSpatialEventTracingTests.ini
@@ -1,8 +1,5 @@
 [/Script/SpatialGDK.SpatialGDKSettings]
 bEventTracingEnabled=True
 
-[/Script/SpatialGDKEditor.SpatialGDKEditorSettings]
-SpatialOSCommandLineLaunchFlags="--event-tracing-enabled=true"
-
 [/Script/UnrealEd.LevelEditorPlaySettings]
 PlayNumberOfClients=1

--- a/Game/Config/MapSettingsOverrides/TestOverridesSpatialEventTracingZoningTests.ini
+++ b/Game/Config/MapSettingsOverrides/TestOverridesSpatialEventTracingZoningTests.ini
@@ -1,8 +1,5 @@
 [/Script/SpatialGDK.SpatialGDKSettings]
 bEventTracingEnabled=True
 
-[/Script/SpatialGDKEditor.SpatialGDKEditorSettings]
-SpatialOSCommandLineLaunchFlags="--event-tracing-enabled=true"
-
 [/Script/UnrealEd.LevelEditorPlaySettings]
 PlayNumberOfClients=1


### PR DESCRIPTION
## Description
`SpatialOSCommandLineLaunchFlags` is no longer required since the runtime switched from using cli flags to the generated config (which is based off the GDK setting for local/cloud workflows)