### PR TITLE
Fix generate schema error by replace handover with server only tag.

### DIFF
--- a/Game/Source/GDKTestGyms/Private/DeterministicBlackboardValues.cpp
+++ b/Game/Source/GDKTestGyms/Private/DeterministicBlackboardValues.cpp
@@ -6,7 +6,7 @@
 #include "AIController.h"
 #include "BehaviorTree/BlackboardComponent.h"
 #include "NavigationSystem.h"
-#include "Engine/DemoNetDriver.h"
+#include "Net/UnrealNetwork.h"
 
 DEFINE_LOG_CATEGORY(LogDeterministicBlackboardValues);
 

--- a/Game/Source/GDKTestGyms/Private/DeterministicBlackboardValues.cpp
+++ b/Game/Source/GDKTestGyms/Private/DeterministicBlackboardValues.cpp
@@ -6,8 +6,17 @@
 #include "AIController.h"
 #include "BehaviorTree/BlackboardComponent.h"
 #include "NavigationSystem.h"
+#include "Engine/DemoNetDriver.h"
 
 DEFINE_LOG_CATEGORY(LogDeterministicBlackboardValues);
+
+void UDeterministicBlackboardValues::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+	DOREPLIFETIME_CONDITION(ThisClass, BlackboardValues, COND_ServerOnly);
+}
+
 
 void UDeterministicBlackboardValues::InitialApplyBlackboardValues() // Repeats until the Component is added 
 {

--- a/Game/Source/GDKTestGyms/Public/DeterministicBlackboardValues.h
+++ b/Game/Source/GDKTestGyms/Public/DeterministicBlackboardValues.h
@@ -26,9 +26,11 @@ public:
 	UFUNCTION(Client, Reliable)
 	void ClientSetBlackboardAILocations(const FBlackboardValues& InBlackboardValues);
 
+	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
 protected:
 	FTimerHandle TimerHandle;
 
-	UPROPERTY(Handover)
+	UPROPERTY(Replicated)
 	FBlackboardValues BlackboardValues;
 };


### PR DESCRIPTION
Fix generate schema error.
Replace `Handover` with `Cond_ServerOnly` tag.

There was a time gap between `UNR-5447` and `UNR-5543`, so they missed it.
When raise PR, there was a pre merge check, which did not include another PR which was in review.