### PR TITLE
Makes `dry-run/*`, `skip-ci/`, `doc/*` &  `docs/*` branches exempt from premerge

### DIFF
--- a/.buildkite/premerge.definition.yaml
+++ b/.buildkite/premerge.definition.yaml
@@ -2,6 +2,7 @@ agent_queue_id: trigger-pipelines
 description: TestGyms premerge (calls GDK premerge)
 github:
   default_branch: master
+  branch_configuration: ['!dry-run/* !skip-ci/* !doc/* !docs/*']
   pull_request_branch_filter_configuration: ['!dry-run/* !skip-ci/* !doc/* !docs/*']
 teams:
 - name: Everyone

--- a/.buildkite/premerge.definition.yaml
+++ b/.buildkite/premerge.definition.yaml
@@ -2,7 +2,7 @@ agent_queue_id: trigger-pipelines
 description: TestGyms premerge (calls GDK premerge)
 github:
   default_branch: master
-  pull_request_branch_filter_configuration: ["!docs*"]
+  pull_request_branch_filter_configuration: ['!dry-run/* !skip-ci/* !doc/* !docs/*']
 teams:
 - name: Everyone
   permission: BUILD_AND_READ


### PR DESCRIPTION
For full description, see: https://github.com/spatialos/UnrealGDK/pull/3176