### PR TITLE
Decrease server move frequency

### DIFF
--- a/Game/Config/DefaultGame.ini
+++ b/Game/Config/DefaultGame.ini
@@ -25,3 +25,8 @@ MaxSpectators=1000
 +WhitelistConfigFiles=GDKTestGyms/Config/MapSettingsOverrides/TestOverridesSpatialEventTracingGroup.ini
 +WhitelistConfigFiles=GDKTestGyms/Config/MapSettingsOverrides/TestOverridesSpatialSnapshotTestPart1Map.ini
 +WhitelistConfigFiles=GDKTestGyms/Config/MapSettingsOverrides/TestOverridesSpatialSnapshotTestPart2Map.ini
+
+[/Script/Engine.GameNetworkManager]
+ClientNetSendMoveDeltaTime=0.0333
+ClientNetSendMoveDeltaTimeThrottled=0.0333
+ClientNetSendMoveDeltaTimeStationary=0.0333


### PR DESCRIPTION
Clients now send server moves at a frequency no greater than server tick rate.

Test run - https://buildkite.com/improbable/unrealgdk-nfr/builds/5653