### PR TITLE
Revert #418

### DIFF
--- a/.buildkite/premerge.definition.yaml
+++ b/.buildkite/premerge.definition.yaml
@@ -2,8 +2,8 @@ agent_queue_id: trigger-pipelines
 description: TestGyms premerge (calls GDK premerge)
 github:
   default_branch: master
-  branch_configuration: ['!dry-run/* !skip-ci/* !doc/* !docs/*']
-  pull_request_branch_filter_configuration: ['!dry-run/* !skip-ci/* !doc/* !docs/*']
+  branch_configuration: []
+  pull_request_branch_filter_configuration: []
 teams:
 - name: Everyone
   permission: BUILD_AND_READ


### PR DESCRIPTION
Reverts: https://github.com/spatialos/UnrealGDKTestGyms/pull/418

We were forced to pick a [different approach](https://improbableio.atlassian.net/browse/UNR-4903?focusedCommentId=451317).

The `circle ci pipeline check` output for this change is:

```ERRO Pipeline not as expected, would apply the following diff:
     @@ -4,10 +4,10 @@
      ID: ""
      Name: unrealgdktestgyms-premerge
      ProviderSettings:
     -  branch_configuration: '!dry-run/* !skip-ci/* !doc/* !docs/*'
     +  branch_configuration: ""
        publish_commit_status_per_step: true
     -  pull_request_branch_filter_configuration: '!dry-run/* !skip-ci/* !doc/* !docs/*'
     -  pull_request_branch_filter_enabled: true
     +  pull_request_branch_filter_configuration: ""
     +  pull_request_branch_filter_enabled: false
      Repository:
        url: git@github.com:spatialos/UnrealGDKTestGyms.git
      Slug: ""