### PR TITLE
Fix checks for multiple actor counts

### DIFF
--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.cpp
@@ -973,8 +973,7 @@ void ABenchmarkGymGameModeBase::UpdateAndCheckTotalActorCounts()
 		{
 			// Check for test failure
 			const FExpectedActorCountConfig& ExpectedActorCount = ExpectedActorCounts[ActorClass];
-			bool bActorCountFailed = TotalActorCount < ExpectedActorCount.MinCount || TotalActorCount > ExpectedActorCount.MaxCount;
-			if (bActorCountFailed)
+			if (TotalActorCount < ExpectedActorCount.MinCount || TotalActorCount > ExpectedActorCount.MaxCount)
 			{
 				bActorCountFailureState = true;
 				if (!bHasActorCountFailed)

--- a/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
+++ b/Game/Source/GDKTestGyms/BenchmarkGymGameModeBase.h
@@ -123,9 +123,8 @@ private:
 	bool bHasUxFailed;
 	bool bHasFpsFailed;
 	bool bHasClientFpsFailed;
-	bool bHasActorCountFailed;
-	// bActorCountFailureState will be true if the test has failed
-	bool bActorCountFailureState;
+	bool bHasActorCountFailed;	// Stores if the actor count check has ever failed.
+	bool bActorCountFailureState; // Stores the *current* failure state of the Actor Count checks.
 	int32 UXAuthActorCount;
 
 	FMetricTimer PrintMetricsTimer;


### PR DESCRIPTION
Previously we were allowing failures to go unreported if they weren't the last actor count checked in Spatial runs.